### PR TITLE
Add NO_PGXS condition to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ ORACLE_SHLIB=$(if $(findstring win32,$(PORTNAME)),oci,clntsh)
 PG_CPPFLAGS = -I$(ORACLE_HOME)/sdk/include -I$(ORACLE_HOME)/oci/include -I$(ORACLE_HOME)/rdbms/public -I/usr/include/oracle/12.1/client -I/usr/include/oracle/12.1/client64 -I/usr/include/oracle/11.2/client -I/usr/include/oracle/11.2/client64 -I/usr/include/oracle/11.1/client -I/usr/include/oracle/11.1/client64 -I/usr/include/oracle/10.2.0.5/client -I/usr/include/oracle/10.2.0.5/client64 -I/usr/include/oracle/10.2.0.4/client -I/usr/include/oracle/10.2.0.4/client64 -I/usr/include/oracle/10.2.0.3/client -I/usr/include/oracle/10.2.0.3/client64
 SHLIB_LINK = -L$(ORACLE_HOME) -L$(ORACLE_HOME)/bin -L$(ORACLE_HOME)/lib -l$(ORACLE_SHLIB) -L/usr/lib/oracle/12.1/client/lib -L/usr/lib/oracle/12.1/client64/lib -L/usr/lib/oracle/11.2/client/lib -L/usr/lib/oracle/11.2/client64/lib -L/usr/lib/oracle/11.1/client/lib -L/usr/lib/oracle/11.1/client64/lib -L/usr/lib/oracle/10.2.0.5/client/lib -L/usr/lib/oracle/10.2.0.5/client64/lib -L/usr/lib/oracle/10.2.0.4/client/lib -L/usr/lib/oracle/10.2.0.4/client64/lib -L/usr/lib/oracle/10.2.0.3/client/lib -L/usr/lib/oracle/10.2.0.3/client64/lib
 
+ifdef NO_PGXS
+subdir = contrib/oracle_fdw
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+else
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+endif

--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -451,6 +451,10 @@ Then the software installation should be as simple as
 For the second step you need write permission to PostgreSQL's shared library
 directory.
 
+If you want to build oracle_fdw in a source tree of PostgreSQL, use
+
+ $ make NO_PGXS=1
+
 Installing the extension:
 -------------------------
 


### PR DESCRIPTION
In order to compile the extension inside the PostgreSQL
source tree (under contrib/), use 'make NO_PGXS=1'.
