### PR TITLE
Add read support for PostGIS.

### DIFF
--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -296,11 +296,16 @@ TIMESTAMP WITH LOCAL TIME ZOME | date, timestamp, timestamptz, char,
                                |   varchar, text
 INTERVAL YEAR TO MONTH         | interval, char, varchar, text
 INTERVAL DAY TO SECOND         | interval, char, varchar, text
+MDSYS.SDO_GEOMETRY             | geometry, bytea (read-only)
 
 If a NUMBER is converted to a boolean, "0" means "false", everything else "true".
 
 NCLOB is currently not supported because Oracle cannot automatically convert
 it to the client encoding.
+
+The data type "geometry" is only available when PostGIS is installed.
+When geometry data are converted to bytea, the WKB (well-known binary) format
+will be used.
 
 If you need conversions exceeding the above, define an appropriate view in
 Oracle or PostgreSQL.

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -42,6 +42,7 @@ typedef enum
 	ORA_TYPE_BFILE,
 	ORA_TYPE_LONG,
 	ORA_TYPE_LONGRAW,
+	ORA_TYPE_GEOMETRY,
 	ORA_TYPE_OTHER
 } oraType;
 
@@ -66,6 +67,7 @@ struct oraColumn
 	unsigned short val_len;  /* actual length of val */
 	unsigned int val_len4;   /* actual length of val - for bind callbacks */
 	short val_null;          /* indicator for NULL value */
+	int srid;                /* spatial reference system identifier (for geometry data) */
 };
 
 struct oraTable


### PR DESCRIPTION
Now Oracle's MDSYS.SDO_GEOMETRY type can be translated to a PostGIS "geometry" automatically.
This is done by using WKB (well-known binary) format for data transfer, which is not ideal for performance as Oracle's SDO_UTIL.TO_WKBGEOMETRY isn't, but avoids messing with internals.

Thanks to Vincent Picavet and Vincent Mora for their help!

Still missing:
- RETURNING support for geometries.
- INSERT and UPDATE of geometries.
