### PR TITLE
Ignore SDO_GEOMETRY elements with zero SDO_ETYPE.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,9 @@ Version 1.3.0
     Per report from Bevan Jenkins.
   - Some point geometries were not translated properly.
     Per report from Bevan Jenkins.
+  - Ignore SDO_GEOMETRY elements with zero SDO_ETYPE.
+    According to Oracle, that is the correct behaviour.
+    Per report from Bevan Jenkins.
 
 Version 1.2.0, released 2015-01-03
   Enhancements:

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -164,6 +164,11 @@ typedef struct
 {
 	struct sdo_geometry *geometry;
 	struct sdo_geometry_ind *indicator;
+	/* the following fields are extracted from "geometry" by unpack() */
+	int num_elems;   /* number of SDO_ELEM_INFO entries, -1 for "not unpacked" */
+	unsigned *elem;  /* unpacked SDO_ELEM_INFO entries */
+	int num_coords;  /* number of SDO_ORDINATES entries, -1 for "not unpacked" */
+	double *coord;   /* unpacked SDO_ORDINATES entries */
 } ora_geometry;
 
 /*

--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -63,7 +63,7 @@ static struct envEntry *envlist = NULL;
 /*
  * NULL value used for "in" callback in RETURNING clauses.
  */
-static ora_geometry null_geometry = { NULL, NULL };
+static ora_geometry null_geometry = { NULL, NULL, -1, NULL, -1, NULL };
 
 /*
  * Helper functions
@@ -1715,6 +1715,10 @@ oraclePrepareQuery(oracleSession *session, const char *query, const struct oraTa
 					ora_geometry *geom = (ora_geometry *)oraTable->cols[i]->val;
 					geom->geometry = NULL;
 					geom->indicator = NULL;
+					geom->num_elems = -1;
+					geom->elem = NULL;
+					geom->num_coords = -1;
+					geom->coord = NULL;
 
 					/* define the result for the named type */
 					if (checkerr(


### PR DESCRIPTION
Introduces a new function `unpack()` that extracts the SDO_ELEM_INFO and SDO_ORDINATE collections and does the necessary preprocessing to remove elements with SDO_ETYPE 0.
The data are stored in new fields in `struct ora_geometry`.
This function is called at the beginning of `oracleGetEWKBLen()`.

Another new function `freeUnpacked()` frees the memory allocated by `unpack()` and is called at the end of `oracleFillEWKB()`.

This patch looks quite intrusive, but apart from the above, all changes should look like this:
* `numElemInfo(session, geom)` is replaced with `geom->num_elems`.
* `elemInfo(session, geom, i)` is replaced with `geom->elem[i]`.
* `numCoord(session, geom)` is replaced with `geom->num_coords`.
* `coord(session, geom, i)` is replaced with `geom->coord[i]`.

That way I don't have to mess with the internals of your code.