### PR TITLE
Fix typo in acquireSampleRowsFunc

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -2556,7 +2556,7 @@ char
 #ifndef OLD_FDW_API
 /*
  * acquireSampleRowsFunc
- * 		Perform a sequential scan on the Oracle table and return a sampe of rows.
+ * 		Perform a sequential scan on the Oracle table and return a sample of rows.
  * 		All LOB values are truncated to WIDTH_THRESHOLD+1 because anything
  * 		exceeding this is not used by compute_scalar_stats().
  */


### PR DESCRIPTION
Hi Laurenz,

I found a typo in comment of acquireSampleRowsFunc.

s/sampe of rows/sample of rows/

Thanks,
Tatsuro Yamada