### PR TITLE
Some Windows improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ results
 # other version control systems
 CVS
 .svn
+
+# Windows build, build output
+v15
+msvc/*.opensdf
+msvc/*.sdf
+msvc/*.suo
+msvc/*.vcxproj.filters
+msvc/Win32
+msvc/x64

--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -539,14 +539,15 @@ Building oracle_fdw:
 --------------------
 
 oracle_fdw has been written as a PostgreSQL extension and uses the Extension
-Building Infrastructure PGXS.  It should be easy to install.
+Building Infrastructure PGXS on all platforms except Windows.  It should be
+easy to install.  For Windows, see the next section.
 
 You will need PostgreSQL headers and PGXS installed (if your PostgreSQL was
 installed with packages, install the development package).  
 You need to install Oracle's C header files as well (SDK package for Instant
-Client).  If you use the Instant Client ZIP files provided by Oracle and you
-are not on Windows, you will have to create a symbolic link from `libclntsh.so`
-to the actual shared library file yourself.
+Client).  If you use the Instant Client ZIP files provided by Oracle,
+you will have to create a symbolic link from `libclntsh.so` to the
+actual shared library file yourself.
 
 Make sure that PostgreSQL is configured `--without-ldap` (at least the server).
 See the [Problems](#8-problems) section.
@@ -567,6 +568,37 @@ PostgreSQL is installed.
 If you want to build oracle_fdw in a source tree of PostgreSQL, use
 
     $ make NO_PGXS=1
+
+Building oracle_fdw on Windows:
+-------------------------------
+
+To build oracle_fdw on Windows, you need:
+
+- PostgreSQL headers and libraries. These can be found in the PostgreSQL
+  installation directory.
+- Oracle headers and libraries (SDK package for Instant Client).
+- Microsoft Visual Studio 2013 or later.
+
+To build, either open `oracle_fdw\msvc\oracle_fdw.sln` in the IDE, or:
+
+- Open a development command prompt (either x86 or x64 depending on your
+  PostgreSQL installation) and change to the `oracle_fdw\msvc` directory.
+- Run (single command line):
+
+      > msbuild oracle_fdw.sln /p:Configuration=(Debug or Release) ^
+            /p:Platform=(Win32 or x64) ^
+            /p:OracleClient=(path to Oracle Client/SDK) ^
+            /p:PostgreSQL=(path to PostgreSQL installation)
+
+  (The "^"s are line continuations; you can just put everything on a single
+line instead.)
+
+When the build is complete, you will find `oracle_fdw.dll` in a subdirectory
+named for your build options, e.g. `x64\Release`.
+
+If you use Visual Studio 2015 or later and you get errors about missing
+header files including `sys/types.h`, you must install the Universal CRT
+SDK (part of Visual Studio).
 
 Installing the extension:
 -------------------------

--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -830,6 +830,28 @@ even if no modification of remote data is attempted.
 It can occur with Oracle server 8.1.7.4 (install one-off patch 2728408) or
 Oracle server 9.2 (install Patch Set 9.2.0.4 or better).
 
+Missing Oracle client DLL (on Windows only)
+-------------------------------------------
+
+The following error message (from any query involving an Oracle foreign
+table) indicates that PostgreSQL cannot find the Oracle client library:
+
+    ERROR:  Oracle client library (oci.dll) not found
+    DETAIL:  No Oracle client is installed, or your system is configured incorrectly.
+    HINT:  Verify that the PATH variable includes the Oracle client.
+
+Make sure that the path to `oci.dll` is in the environment of the user
+running the PostgreSQL server. If it is running as a Windows service, this
+is the system environment, and you must restart the service after changing
+it.
+
+If updating the environment does not work, you may be using a PostgreSQL
+distribution that provides its own environment variables, hiding the Oracle
+client.  See [this bug
+report](https://github.com/laurenz/oracle_fdw/issues/160) for more
+information.
+
+
 9 Support
 =========
 
@@ -847,3 +869,4 @@ If you have a problem or question or any kind of feedback, the preferred
 option is to open an issue on GitHub:  
 https://github.com/laurenz/oracle_fdw/issues  
 This requires a GitHub account.
+

--- a/msvc/oracle_fdw.props
+++ b/msvc/oracle_fdw.props
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="$(Platform)=='x64'">
+    <OracleClient>C:\Daten\work\install\oracle64\instantclient_10_2</OracleClient>
+    <PostgreSQL>C:\Daten\pgsql\pg10-x64</PostgreSQL>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Platform)=='Win32'">
+    <OracleClient>C:\Daten\work\install\oracle32\instantclient_10_2</OracleClient>
+    <PostgreSQL>C:\Daten\pgsql\pg10-x86</PostgreSQL>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IncludePath>$(PostgreSQL)\include\server\port\win32_msvc;$(PostgreSQL)\include\server\port\win32;$(PostgreSQL)\include\server\port;$(PostgreSQL)\include\server;$(PostgreSQL)\include\internal;$(PostgreSQL)\include;$(OracleClient)\sdk\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(PostgreSQL)\lib;$(OracleClient)\sdk\lib\msvc;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup />
+  <ItemGroup />
+</Project>

--- a/msvc/oracle_fdw.sln
+++ b/msvc/oracle_fdw.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "oracle_fdw", "oracle_fdw.vcxproj", "{E4E300FC-E7CE-4BAA-9028-AA348F977376}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Debug|Win32.Build.0 = Debug|Win32
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Debug|x64.ActiveCfg = Debug|x64
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Debug|x64.Build.0 = Debug|x64
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Release|Win32.ActiveCfg = Release|Win32
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Release|Win32.Build.0 = Release|Win32
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Release|x64.ActiveCfg = Release|x64
+		{E4E300FC-E7CE-4BAA-9028-AA348F977376}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/msvc/oracle_fdw.vcxproj
+++ b/msvc/oracle_fdw.vcxproj
@@ -94,10 +94,12 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>postgres.lib;oci.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>oci.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -109,10 +111,12 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>postgres.lib;oci.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>oci.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -125,12 +129,14 @@
       <OmitFramePointers>true</OmitFramePointers>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>postgres.lib;oci.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>oci.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -143,18 +149,21 @@
       <OmitFramePointers>true</OmitFramePointers>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>postgres.lib;oci.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>oci.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\oracle_fdw.c" />
     <ClCompile Include="..\oracle_gis.c" />
     <ClCompile Include="..\oracle_utils.c" />
+    <ClCompile Include="oracle_msvc.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\oracle_fdw.h" />

--- a/msvc/oracle_fdw.vcxproj
+++ b/msvc/oracle_fdw.vcxproj
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E4E300FC-E7CE-4BAA-9028-AA348F977376}</ProjectGuid>
+    <RootNamespace>oracle_fdw</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="oracle_fdw.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="oracle_fdw.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="oracle_fdw.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="oracle_fdw.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <OmitFramePointers>false</OmitFramePointers>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <OmitFramePointers>false</OmitFramePointers>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <OmitFramePointers>true</OmitFramePointers>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <OmitFramePointers>true</OmitFramePointers>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4200;4244;4267;4389;4018;4996;4100;4127</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>postgres.lib;oci.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\oracle_fdw.c" />
+    <ClCompile Include="..\oracle_gis.c" />
+    <ClCompile Include="..\oracle_utils.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\oracle_fdw.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/oracle_msvc.c
+++ b/msvc/oracle_msvc.c
@@ -1,0 +1,59 @@
+#include "..\oracle_fdw.h"
+
+#include "postgres.h"
+#include "utils\elog.h"
+
+#include <windows.h>
+
+#pragma warning(push)
+#pragma warning(disable: 4201)
+#include <delayimp.h>
+#pragma warning(pop)
+
+#define ERRMSG_LIB "Oracle client library (oci.dll) not found"
+#define ERRDETAIL_LIB "No Oracle client is installed, or your system is configured incorrectly."
+#define ERRMSG_PROC "Incompatible version of Oracle client library (oci.dll) found"
+#define ERRDETAIL_PROC "An exported function was not found in oci.dll."
+
+FARPROC WINAPI
+oracleDelayLoadFailureHook(unsigned dliNotify, PDelayLoadInfo pdli)
+{
+	if (dliNotify == dliFailLoadLib) {
+#if defined(ORAFDW_INSECURE_DIAG)
+		ereport(ERROR,
+			(errcode(ERRCODE_SYSTEM_ERROR),
+			errmsg(ERRMSG_LIB),
+			errdetail(ERRDETAIL_LIB),
+			errhint("The current PATH is: %s", getenv("PATH"))));
+#else
+		ereport(ERROR,
+			(errcode(ERRCODE_SYSTEM_ERROR),
+			errmsg(ERRMSG_LIB),
+			errdetail(ERRDETAIL_LIB),
+			errhint("Verify that the PATH variable includes the Oracle client.")));
+#endif	/* ORAFDW_INSECURE_DIAG */
+	}
+	else if (dliNotify == dliFailGetProc) {
+		/* There are no exports by ordinal yets. */
+		if (pdli->dlp.fImportByName) {
+			ereport(ERROR,
+				(errcode(ERRCODE_SYSTEM_ERROR),
+				errmsg(ERRMSG_PROC),
+				errdetail(ERRDETAIL_PROC),
+				errhint("Missing function: %s", pdli->dlp.szProcName)));
+		}
+		else {
+			ereport(ERROR,
+				(errcode(ERRCODE_SYSTEM_ERROR),
+				errmsg(ERRMSG_PROC),
+				errdetail(ERRDETAIL_PROC),
+				errhint("Missing ordinal: #%u", pdli->dlp.dwOrdinal)));
+		}
+	}
+	return 0;
+}
+
+#if _MSC_VER >= 1900
+const
+#endif
+PfnDliHook __pfnDliFailureHook2 = oracleDelayLoadFailureHook;


### PR DESCRIPTION
Two things (in two commits):

1. A basic Windows build setup that works from the Visual Studio IDE as well as on the command line.
   The dependency paths (Oracle, PostgreSQL) are configured in the oracle_fdw.props file, the project file itself contains the parts that do not change.

   Build instructions:

   - Set the paths to Oracle and PostgreSQL in oracle_fdw.props.
   - `msbuild msvc\oracle_fdw.sln /p:Configuration=(Debug|Release) /p:Platform=(Win32|x64)`
   - Output will be in `msvc\$(Platform)\$(Configuration)`

   This is the whole story for VS 2013; with 2015 and later, an additional argument to msbuild is needed:

   `/p:WindowsTargetPlatformVersion=...`, where the "..." is whichever SDK to build with to get the CRT selection right, such as `10.0.16299.0` for the latest Windows 10 1709 (the code will still run on anything earlier as long as the UCRT is installed).

   The `$(OracleClient)` and `$(PostgreSQL)` properties can also be overridden on the msbuild command line using the same `/p:` syntax as above, e.g. for use in build scripts to generate releases for all PostgreSQL versions at once.

2. An idea for how to reduce the number of bug reports with DLL/path issues.
   Windows supports delayed loading of DLLs; they are loaded when the first call to any of their exported functions is made. Using this feature for oci.dll allows oracle_fdw to produce useful diagnostics ("Cannot find oci.dll") rather than the default behavior where the error message from PostgreSQL core reads as if oracle_fdw.dll itself cannot be found.
   A particularly nice touch (if I say so myself) to this is that it requires exactly *no* changes to the existing code; it works simply by linking in the additional object file. The PGXS build should be entirely unaffected.

The existing regression tests pass with 11g XE, except the XML test at the bottom of `oracle_fdw.sql` (PostgreSQL built without libxml2) and `oracle_gis.sql` (no spatial support in my [or any?] XE).