### PR TITLE
Fix the required oracle client version from 10.1 to 10.2 in README.

### DIFF
--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -520,7 +520,7 @@ If you want to try it nonetheless, you'll have to build oracle_fdw from source.
 If you encounter problems while using such a PostgreSQL-derived server,
 please try with the original version before reporting an issue.
 
-Oracle client version 10.1 or better is required.  
+Oracle client version 10.2 or better is required.
 oracle_fdw can be built and used with Oracle Instant Client as well as with
 Oracle Client and Server installations installed with Universal Installer.
 Binaries compiled with Oracle Client 10 can be used with later client versions


### PR DESCRIPTION
Hi, 

When I read README, I understand that Oracle client version 10.1 or better is required. 
However, I think it is correct that oracle_fdw could be used with "Oracle client version 10.2 or better". 

Seeing Makefile, I think 10.2.0.3 Client is the lower limit. 
Moreover, this [PR](https://github.com/laurenz/oracle_fdw/commit/9b6e4aceea79bc8c3abbe855dd5d4909559cf510#diff-76199f4d58621f6fc0dd604f26fb258b) introduce OCIClientVersion which is the new feature in 10.2. 
http://web.deu.edu.tr/doc/oracle/B19306_01/appdev.102/b14250/whatsnew.htm#CJABBBGI

In my testing, compiling oracle_fdw with 10.1.0.5 is not failed. 
However, "CREATE EXTENSION oracle_fdw" is failed because of undefined symbol: OCIClientVersion

I submit the fix for README. 

Regards, 
Daisuke, Higuchi 
