### PR TITLE
Make Release the default configuration.

### DIFF
--- a/msvc/oracle_fdw.vcxproj
+++ b/msvc/oracle_fdw.vcxproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>


### PR DESCRIPTION
This works only if building from the project file; the solution will still default to Debug.

    msbuild oracle_fdw.vcxproj