### PR TITLE
New SERVER option "isolation_level" (TODO 2, #250)

### DIFF
--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -160,6 +160,12 @@ Foreign server options
   Oracle client is configured accordingly.  
   Set this to an empty string for local ("BEQUEATH") connections.
 
+- **isolation_level** (optional, defaults to "serializable")
+
+  Set the Transaction Isolation Level when connecting to the Oracle database.  
+  The value can be: serializable, read_committed, read_write(not commonly used)
+  and read_only.
+
 User mapping options
 --------------------
 

--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -163,8 +163,7 @@ Foreign server options
 - **isolation_level** (optional, defaults to "serializable")
 
   Set the Transaction Isolation Level when connecting to the Oracle database.  
-  The value can be: serializable, read_committed, read_write(not commonly used)
-  and read_only.
+  The value can be: serializable, read_committed and read_only.
 
 User mapping options
 --------------------

--- a/TODO
+++ b/TODO
@@ -5,5 +5,3 @@ Help is welcome!
   established.  Otherwise, an ill-guided Oracle logon trigger could mess up
   our NLS settings.
 
-- Add an (unsafe!) option to use READ COMMITTED instead of SERIALIZABLE
-  for Oracle transactions.  See issue #250.

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -568,3 +568,74 @@ ORDER BY id;
   3
 (2 rows)
 
+/*
+ * Test Transaction Isolation Level
+ */
+-- testcase for OPTION isolation_level = serializable
+CREATE SERVER oracle1 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'serializable');
+CREATE USER MAPPING FOR PUBLIC SERVER oracle1 OPTIONS (user 'SCOTT', password 'tiger');
+CREATE FOREIGN TABLE shorty1 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle1 OPTIONS (table 'TYPETEST1');
+INSERT INTO shorty1 (id, c) VALUES (1000, 's');
+SELECT id, c FROM shorty1 WHERE id = 1000;
+  id  |     c      
+------+------------
+ 1000 | s         
+(1 row)
+
+-- testcase for OPTION isolation_level = read_committed
+CREATE SERVER oracle2 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed');
+CREATE USER MAPPING FOR PUBLIC SERVER oracle2 OPTIONS (user 'SCOTT', password 'tiger');
+CREATE FOREIGN TABLE shorty2 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle2 OPTIONS (table 'TYPETEST1');
+INSERT INTO shorty2 (id, c) VALUES (1001, 'rc');
+SELECT id, c FROM shorty2 WHERE id = 1001;
+  id  |     c      
+------+------------
+ 1001 | rc        
+(1 row)
+
+-- testcase for OPTION isolation_level = read_write (not commonly used)
+CREATE SERVER oracle3 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_write');
+CREATE USER MAPPING FOR PUBLIC SERVER oracle3 OPTIONS (user 'SCOTT', password 'tiger');
+CREATE FOREIGN TABLE shorty3 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle3 OPTIONS (table 'TYPETEST1');
+INSERT INTO shorty3 (id, c) VALUES (1002, 'rw');
+SELECT id, c FROM shorty3 WHERE id = 1002;
+  id  |     c      
+------+------------
+ 1002 | rw        
+(1 row)
+
+-- testcase for OPTION isolation_level = read_only
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_only');
+CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
+CREATE FOREIGN TABLE shorty4 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle4 OPTIONS (table 'TYPETEST1');
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001, 1002);
+  id  |     c      
+------+------------
+ 1000 | s         
+ 1001 | rc        
+ 1002 | rw        
+(3 rows)
+
+INSERT INTO shorty4 (id, c) VALUES (1003, 'ro');
+ERROR:  error executing query: OCIStmtExecute failed to execute remote query
+DETAIL:  ORA-01456: may not perform insert/delete/update operation inside a READ ONLY transaction
+SELECT id, c FROM shorty4 WHERE id = 1003;
+ id | c 
+----+---
+(0 rows)
+
+DELETE FROM shorty1 WHERE id = 1000;
+DELETE FROM shorty2 WHERE id = 1001;
+DELETE FROM shorty3 WHERE id = 1002;

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -621,6 +621,66 @@ SELECT id, c FROM shorty3 WHERE id = 1002;
 ----+---
 (0 rows)
 
+-- testcase for OPTION isolation_level =
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level);
+ERROR:  syntax error at or near ")"
+LINE 1: ...A WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level);
+                                                                     ^
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level '');
+ERROR:  invalid value for option "isolation_level"
+HINT:  Valid values in this context are: serializable/read_committed/read_only
+-- testcase for OPTION isolation_level = unknow
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'unknow');
+ERROR:  invalid value for option "isolation_level"
+HINT:  Valid values in this context are: serializable/read_committed/read_only
+CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
+ERROR:  server "oracle4" does not exist
+CREATE FOREIGN TABLE shorty4 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle4 OPTIONS (table 'TYPETEST1');
+ERROR:  server "oracle4" does not exist
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+ERROR:  relation "shorty4" does not exist
+LINE 1: SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+                          ^
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '');
+CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
+CREATE FOREIGN TABLE shorty4 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle4 OPTIONS (table 'TYPETEST1');
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+  id  |     c      
+------+------------
+ 1000 | s         
+ 1001 | rc        
+(2 rows)
+
+ALTER SERVER oracle4 OPTIONS (isolation_level 'read_only');
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+  id  |     c      
+------+------------
+ 1000 | s         
+ 1001 | rc        
+(2 rows)
+
+INSERT INTO shorty4 (id, c) VALUES (1002, 'ro');
+ERROR:  error executing query: OCIStmtExecute failed to execute remote query
+DETAIL:  ORA-01456: may not perform insert/delete/update operation inside a READ ONLY transaction
+ALTER SERVER oracle4 OPTIONS (SET isolation_level 'unknow');
+ERROR:  invalid value for option "isolation_level"
+HINT:  Valid values in this context are: serializable/read_committed/read_only
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+  id  |     c      
+------+------------
+ 1000 | s         
+ 1001 | rc        
+(2 rows)
+
+INSERT INTO shorty4 (id, c) VALUES (1002, 'ro');
+ERROR:  error executing query: OCIStmtExecute failed to execute remote query
+DETAIL:  ORA-01456: may not perform insert/delete/update operation inside a READ ONLY transaction
 DELETE FROM shorty1 WHERE id = 1000;
 DELETE FROM shorty2 WHERE id = 1001;
 DELETE FROM shorty3 WHERE id = 1002;

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -599,39 +599,24 @@ SELECT id, c FROM shorty2 WHERE id = 1001;
  1001 | rc        
 (1 row)
 
--- testcase for OPTION isolation_level = read_write (not commonly used)
-CREATE SERVER oracle3 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_write');
+-- testcase for OPTION isolation_level = read_only
+CREATE SERVER oracle3 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_only');
 CREATE USER MAPPING FOR PUBLIC SERVER oracle3 OPTIONS (user 'SCOTT', password 'tiger');
 CREATE FOREIGN TABLE shorty3 (
    id  integer OPTIONS (key 'yes') NOT NULL,
    c   character(10)
 ) SERVER oracle3 OPTIONS (table 'TYPETEST1');
-INSERT INTO shorty3 (id, c) VALUES (1002, 'rw');
-SELECT id, c FROM shorty3 WHERE id = 1002;
-  id  |     c      
-------+------------
- 1002 | rw        
-(1 row)
-
--- testcase for OPTION isolation_level = read_only
-CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_only');
-CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
-CREATE FOREIGN TABLE shorty4 (
-   id  integer OPTIONS (key 'yes') NOT NULL,
-   c   character(10)
-) SERVER oracle4 OPTIONS (table 'TYPETEST1');
-SELECT id, c FROM shorty4 WHERE id IN (1000, 1001, 1002);
+SELECT id, c FROM shorty3 WHERE id IN (1000, 1001);
   id  |     c      
 ------+------------
  1000 | s         
  1001 | rc        
- 1002 | rw        
-(3 rows)
+(2 rows)
 
-INSERT INTO shorty4 (id, c) VALUES (1003, 'ro');
+INSERT INTO shorty3 (id, c) VALUES (1002, 'ro');
 ERROR:  error executing query: OCIStmtExecute failed to execute remote query
 DETAIL:  ORA-01456: may not perform insert/delete/update operation inside a READ ONLY transaction
-SELECT id, c FROM shorty4 WHERE id = 1003;
+SELECT id, c FROM shorty3 WHERE id = 1002;
  id | c 
 ----+---
 (0 rows)
@@ -639,3 +624,5 @@ SELECT id, c FROM shorty4 WHERE id = 1003;
 DELETE FROM shorty1 WHERE id = 1000;
 DELETE FROM shorty2 WHERE id = 1001;
 DELETE FROM shorty3 WHERE id = 1002;
+ERROR:  error executing query: OCIStmtExecute failed to execute remote query
+DETAIL:  ORA-01456: may not perform insert/delete/update operation inside a READ ONLY transaction

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -406,13 +406,14 @@ static void appendReturningClause(StringInfo sql, struct OracleFdwState *fdwStat
 #ifdef IMPORT_API
 static char *fold_case(char *name, fold_t foldcase, int collation);
 #endif  /* IMPORT_API */
+static unsigned int getIsolationLevel(const char *isolation_level);
 
 #define REL_ALIAS_PREFIX    "r"
 /* Handy macro to add relation name qualification */
 #define ADD_REL_QUALIFIER(buf, varno)   \
 		appendStringInfo((buf), "%s%d.", REL_ALIAS_PREFIX, (varno))
 
-static unsigned int getIsolationLevel(const char *isolation_level);
+
 
 /*
  * Foreign-data wrapper handler function: return a struct with pointers

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -65,6 +65,11 @@ struct oracleSession
 #endif
 typedef struct oracleSession oracleSession;
 
+/* Oracle transaction isolation flags */
+#define ORA_TRANS_NEW          0x00000001
+#define ORA_TRANS_READONLY     0x00000100
+#define ORA_TRANS_SERIALIZABLE 0x00000400
+
 /* types for the Oracle table description */
 typedef enum
 {
@@ -187,7 +192,7 @@ typedef struct
 /*
  * functions defined in oracle_utils.c
  */
-extern oracleSession *oracleGetSession(const char *connectstring, char *isolation_level, char *user, char *password, const char *nls_lang, const char *tablename, int curlevel);
+extern oracleSession *oracleGetSession(const char *connectstring, unsigned int isolation_level, char *user, char *password, const char *nls_lang, const char *tablename, int curlevel);
 extern void oracleCloseStatement(oracleSession *session);
 extern void oracleCloseConnections(void);
 extern void oracleShutdown(void);

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -66,9 +66,9 @@ struct oracleSession
 typedef struct oracleSession oracleSession;
 
 /* Oracle transaction isolation flags */
-#define ORA_TRANS_NEW          0x00000001
-#define ORA_TRANS_READONLY     0x00000100
-#define ORA_TRANS_SERIALIZABLE 0x00000400
+#define ORA_TRANS_READ_COMMITTED 0x00000001
+#define ORA_TRANS_READ_ONLY      0x00000100
+#define ORA_TRANS_SERIALIZABLE   0x00000400
 
 /* types for the Oracle table description */
 typedef enum

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -187,7 +187,7 @@ typedef struct
 /*
  * functions defined in oracle_utils.c
  */
-extern oracleSession *oracleGetSession(const char *connectstring, char *user, char *password, const char *nls_lang, const char *tablename, int curlevel);
+extern oracleSession *oracleGetSession(const char *connectstring, char *isolation_level, char *user, char *password, const char *nls_lang, const char *tablename, int curlevel);
 extern void oracleCloseStatement(oracleSession *session);
 extern void oracleCloseConnections(void);
 extern void oracleShutdown(void);

--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -101,7 +101,7 @@ oracleSession
 	char pid[30], *nlscopy = NULL;
 	ub4 is_connected;
 	int retry = 1;
-	ub4 OCI_TRANS_CODE;
+	ub4 OCI_TRANS_CODE = -1;
 	char msg[100];
 
 	/* 
@@ -109,14 +109,18 @@ oracleSession
 	 * Although we define the same value as Oracle defines, 
 	 * but we cannot assure the Oracle's definition will never changed.  
 	 */
-	if (isolation_level == ORA_TRANS_SERIALIZABLE)
-		OCI_TRANS_CODE = OCI_TRANS_SERIALIZABLE;
-    else if (isolation_level == ORA_TRANS_NEW)
-    	OCI_TRANS_CODE = OCI_TRANS_NEW;
-    else if (isolation_level == ORA_TRANS_READONLY)
-        OCI_TRANS_CODE = OCI_TRANS_READONLY;
-    else
-    	OCI_TRANS_CODE = OCI_TRANS_SERIALIZABLE;
+	switch(isolation_level)
+	{
+		case ORA_TRANS_SERIALIZABLE:
+			OCI_TRANS_CODE = OCI_TRANS_SERIALIZABLE;
+			break;
+		case ORA_TRANS_READ_COMMITTED:
+			OCI_TRANS_CODE = OCI_TRANS_NEW;
+			break;
+		case ORA_TRANS_READ_ONLY:
+			OCI_TRANS_CODE = OCI_TRANS_READONLY;
+			break;
+	}
 
 	/* it's easier to deal with empty strings */
 	if (!connectstring)

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -418,3 +418,73 @@ DROP FOREIGN TABLE badtypes;
 SELECT id FROM typetest1
 WHERE vc NOT IN (SELECT * FROM (VALUES ('short'), ('other')) AS q)
 ORDER BY id;
+
+/*
+ * Test Transaction Isolation Level
+ */
+
+-- testcase for OPTION isolation_level = serializable
+CREATE SERVER oracle1 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'serializable');
+
+CREATE USER MAPPING FOR PUBLIC SERVER oracle1 OPTIONS (user 'SCOTT', password 'tiger');
+
+CREATE FOREIGN TABLE shorty1 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle1 OPTIONS (table 'TYPETEST1');
+
+INSERT INTO shorty1 (id, c) VALUES (1000, 's');
+
+SELECT id, c FROM shorty1 WHERE id = 1000;
+
+-- testcase for OPTION isolation_level = read_committed
+CREATE SERVER oracle2 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed');
+
+CREATE USER MAPPING FOR PUBLIC SERVER oracle2 OPTIONS (user 'SCOTT', password 'tiger');
+
+CREATE FOREIGN TABLE shorty2 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle2 OPTIONS (table 'TYPETEST1');
+
+INSERT INTO shorty2 (id, c) VALUES (1001, 'rc');
+
+SELECT id, c FROM shorty2 WHERE id = 1001;
+
+
+-- testcase for OPTION isolation_level = read_write (not commonly used)
+CREATE SERVER oracle3 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_write');
+
+CREATE USER MAPPING FOR PUBLIC SERVER oracle3 OPTIONS (user 'SCOTT', password 'tiger');
+
+CREATE FOREIGN TABLE shorty3 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle3 OPTIONS (table 'TYPETEST1');
+
+INSERT INTO shorty3 (id, c) VALUES (1002, 'rw');
+
+SELECT id, c FROM shorty3 WHERE id = 1002;
+
+
+-- testcase for OPTION isolation_level = read_only
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_only');
+
+CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
+
+CREATE FOREIGN TABLE shorty4 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle4 OPTIONS (table 'TYPETEST1');
+
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001, 1002);
+
+INSERT INTO shorty4 (id, c) VALUES (1003, 'ro');
+
+SELECT id, c FROM shorty4 WHERE id = 1003;
+
+DELETE FROM shorty1 WHERE id = 1000;
+
+DELETE FROM shorty2 WHERE id = 1001;
+
+DELETE FROM shorty3 WHERE id = 1002;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -467,6 +467,46 @@ INSERT INTO shorty3 (id, c) VALUES (1002, 'ro');
 
 SELECT id, c FROM shorty3 WHERE id = 1002;
 
+-- testcase for OPTION isolation_level =
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level);
+
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level '');
+
+-- testcase for OPTION isolation_level = unknow
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'unknow');
+
+CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
+
+CREATE FOREIGN TABLE shorty4 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle4 OPTIONS (table 'TYPETEST1');
+
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+
+CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '');
+
+CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
+
+CREATE FOREIGN TABLE shorty4 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10)
+) SERVER oracle4 OPTIONS (table 'TYPETEST1');
+
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+
+ALTER SERVER oracle4 OPTIONS (isolation_level 'read_only');
+
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+
+INSERT INTO shorty4 (id, c) VALUES (1002, 'ro');
+
+ALTER SERVER oracle4 OPTIONS (SET isolation_level 'unknow');
+
+SELECT id, c FROM shorty4 WHERE id IN (1000, 1001);
+
+INSERT INTO shorty4 (id, c) VALUES (1002, 'ro');
+
 DELETE FROM shorty1 WHERE id = 1000;
 
 DELETE FROM shorty2 WHERE id = 1001;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -451,9 +451,8 @@ INSERT INTO shorty2 (id, c) VALUES (1001, 'rc');
 
 SELECT id, c FROM shorty2 WHERE id = 1001;
 
-
--- testcase for OPTION isolation_level = read_write (not commonly used)
-CREATE SERVER oracle3 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_write');
+-- testcase for OPTION isolation_level = read_only
+CREATE SERVER oracle3 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_only');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle3 OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -462,26 +461,11 @@ CREATE FOREIGN TABLE shorty3 (
    c   character(10)
 ) SERVER oracle3 OPTIONS (table 'TYPETEST1');
 
-INSERT INTO shorty3 (id, c) VALUES (1002, 'rw');
+SELECT id, c FROM shorty3 WHERE id IN (1000, 1001);
+
+INSERT INTO shorty3 (id, c) VALUES (1002, 'ro');
 
 SELECT id, c FROM shorty3 WHERE id = 1002;
-
-
--- testcase for OPTION isolation_level = read_only
-CREATE SERVER oracle4 FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_only');
-
-CREATE USER MAPPING FOR PUBLIC SERVER oracle4 OPTIONS (user 'SCOTT', password 'tiger');
-
-CREATE FOREIGN TABLE shorty4 (
-   id  integer OPTIONS (key 'yes') NOT NULL,
-   c   character(10)
-) SERVER oracle4 OPTIONS (table 'TYPETEST1');
-
-SELECT id, c FROM shorty4 WHERE id IN (1000, 1001, 1002);
-
-INSERT INTO shorty4 (id, c) VALUES (1003, 'ro');
-
-SELECT id, c FROM shorty4 WHERE id = 1003;
 
 DELETE FROM shorty1 WHERE id = 1000;
 


### PR DESCRIPTION
New SERVER option "isolation_level". This gives a chance to use READ COMMITTED instead of SERIALIZABLE for Oracle transactions.

The "isolation_level" value can be serializable(default), read_committed, read_write(not commonly used) and read_only.
