### PR TITLE
Fix INSERT ... RETURNING when routing tuples to a foreign table

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -1931,26 +1931,23 @@ void oracleBeginForeignInsert(ModifyTableState *mtstate, ResultRelInfo *rinfo)
 			GetCurrentTransactionNestLevel()
 		);
 
-	if (hasTrigger(rinfo->ri_RelationDesc, CMD_INSERT))
-	{
-		/* all attributes are needed for the RETURNING clause */
-		for (i=0; i<fdw_state->oraTable->ncols; ++i)
-			if (fdw_state->oraTable->cols[i]->pgname != NULL)
-			{
-				/* throw an error if it is a LONG or LONG RAW column */
-				if (fdw_state->oraTable->cols[i]->oratype == ORA_TYPE_LONGRAW
-						|| fdw_state->oraTable->cols[i]->oratype == ORA_TYPE_LONG)
-					ereport(ERROR,
-							(errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-							errmsg("columns with Oracle type LONG or LONG RAW cannot be used in RETURNING clause"),
-							errdetail("Column \"%s\" of foreign table \"%s\" is of Oracle type LONG%s.",
-								fdw_state->oraTable->cols[i]->pgname,
-								fdw_state->oraTable->pgname,
-								fdw_state->oraTable->cols[i]->oratype == ORA_TYPE_LONG ? "" : " RAW")));
+	/* all attributes are needed for the RETURNING clause */
+	for (i=0; i<fdw_state->oraTable->ncols; ++i)
+		if (fdw_state->oraTable->cols[i]->pgname != NULL)
+		{
+			/* throw an error if it is a LONG or LONG RAW column */
+			if (fdw_state->oraTable->cols[i]->oratype == ORA_TYPE_LONGRAW
+				|| fdw_state->oraTable->cols[i]->oratype == ORA_TYPE_LONG)
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+						 errmsg("columns with Oracle type LONG or LONG RAW cannot be used in RETURNING clause"),
+						 errdetail("Column \"%s\" of foreign table \"%s\" is of Oracle type LONG%s.",
+								   fdw_state->oraTable->cols[i]->pgname,
+								   fdw_state->oraTable->pgname,
+								   fdw_state->oraTable->cols[i]->oratype == ORA_TYPE_LONG ? "" : " RAW")));
 
-				fdw_state->oraTable->cols[i]->used = 1;
-			}
-	}
+			fdw_state->oraTable->cols[i]->used = 1;
+		}
 
 	/* construct an INSERT query */
 	initStringInfo(&buf);


### PR DESCRIPTION
Previously INSERT ... RETURNING on a partition table, oracle_fdw was returning NULL values for each column specified in the RETURNING clause.

The `hasTrigger()` check seems to be incorrect; in the [equivalent location in postgres_fdw](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=contrib/postgres_fdw/postgres_fdw.c;h=9fc53cad68038f36d009c93daa810028fe889e00;hb=HEAD#l1951) there is no such check.

Oracle:
```
SQL> CREATE TABLE part_test3 (
  id INT NOT NULL,
  val VARCHAR(32)
);
```

Direct insert into foreign table:
```
postgres=# CREATE FOREIGN TABLE part_foreign3 (
             id INT NOT NULL,
             val VARCHAR(32)
           )
           SERVER oradb
           OPTIONS (table 'PART_TEST3');
CREATE FOREIGN TABLE

postgres=# INSERT INTO part_foreign3 values(2091,'moo') returning *;
  id  | val 
------+-----
 2091 | moo
(1 row)

```

Insert via partition table:
```
postgres=# CREATE TABLE part_parent (
             id INT NOT NULL,
             val VARCHAR(32)
           ) PARTITION BY RANGE (id);
CREATE TABLE

postgres=# ALTER TABLE part_parent  ATTACH PARTITION part_foreign3 FOR VALUES FROM (2001) TO (3000);
ALTER TABLE

postgres=# INSERT INTO  part_parent values(2092,'moo') returning *;
 id | val 
----+-----
    | 
(1 row)

```
