### PR TITLE
Pushdown of LIMIT clause

### DIFF
--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -640,3 +640,68 @@ EXECUTE stmt('{varlena,nonsense}');
 (1 row)
 
 DEALLOCATE stmt;
+/*
+ * Test LIMIT clause.
+ */
+-- The limit clause must be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Foreign Scan on public.typetest1
+         Output: d
+         Oracle query: SELECT /*f04d370c8510559c215152b699b07ac5*/ r1."D" FROM "TYPETEST1" r1 FETCH FIRST 2 ROWS ONLY
+         Oracle plan: SELECT STATEMENT
+         Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
+         Oracle plan:     WINDOW NOSORT STOPKEY   (filter ROW_NUMBER() OVER ( ORDER BY  NULL )<=2)
+         Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(9 rows)
+
+SELECT d FROM typetest1 LIMIT 2;
+       d       
+---------------
+ 10-21-1968
+ 03-15-0044 BC
+(2 rows)
+
+-- With an ORDER BY clause the limit clause must NOT be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Foreign Scan on public.typetest1
+         Output: d
+         Oracle query: SELECT /*145d52f5de38a843e3af04dc11eeb80c*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST
+         Oracle plan: SELECT STATEMENT
+         Oracle plan:   SORT ORDER BY
+         Oracle plan:     TABLE ACCESS FULL TYPETEST1
+(8 rows)
+
+SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+       d       
+---------------
+ 03-15-0044 BC
+ 10-21-1968
+(2 rows)
+
+-- With an OFFET clause the limit clause must NOT be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Foreign Scan on public.typetest1
+         Output: d
+         Oracle query: SELECT /*272655bdd593a539434c24523500a6ac*/ r1."D" FROM "TYPETEST1" r1
+         Oracle plan: SELECT STATEMENT
+         Oracle plan:   TABLE ACCESS FULL TYPETEST1
+(7 rows)
+
+SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;
+     d      
+------------
+ 10-21-1968
+(1 row)
+

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -643,7 +643,7 @@ DEALLOCATE stmt;
 /*
  * Test LIMIT clause.
  */
--- The limit clause must be pushed down
+-- The LIMIT clause must be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
@@ -665,21 +665,45 @@ SELECT d FROM typetest1 LIMIT 2;
  03-15-0044 BC
 (2 rows)
 
--- With an ORDER BY clause the limit clause must NOT be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: d
    ->  Foreign Scan on public.typetest1
          Output: d
-         Oracle query: SELECT /*145d52f5de38a843e3af04dc11eeb80c*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST
+         Oracle query: SELECT /*e2f036b94f72638325ef6dc70ad78e76*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST FETCH FIRST 2 ROWS ONLY
          Oracle plan: SELECT STATEMENT
-         Oracle plan:   SORT ORDER BY
-         Oracle plan:     TABLE ACCESS FULL TYPETEST1
-(8 rows)
+         Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
+         Oracle plan:     WINDOW SORT PUSHED RANK   (filter ROW_NUMBER() OVER ( ORDER BY "R1"."D")<=2)
+         Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(9 rows)
 
 SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+       d       
+---------------
+ 03-15-0044 BC
+ 10-21-1968
+(2 rows)
+
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 GROUP BY d LIMIT 2;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Group
+         Output: d
+         Group Key: typetest1.d
+         ->  Foreign Scan on public.typetest1
+               Output: d
+               Oracle query: SELECT /*e2f036b94f72638325ef6dc70ad78e76*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST FETCH FIRST 2 ROWS ONLY
+               Oracle plan: SELECT STATEMENT
+               Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
+               Oracle plan:     WINDOW SORT PUSHED RANK   (filter ROW_NUMBER() OVER ( ORDER BY "R1"."D")<=2)
+               Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(12 rows)
+
+SELECT d FROM typetest1 GROUP BY d LIMIT 2;
        d       
 ---------------
  03-15-0044 BC

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -686,7 +686,7 @@ SELECT d FROM typetest1 ORDER BY d LIMIT 2;
  10-21-1968
 (2 rows)
 
--- With an OFFET clause the limit clause must NOT be pushed down
+-- With an OFFSET clause the limit clause must NOT be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -710,18 +710,20 @@ SELECT d FROM typetest1 GROUP BY d LIMIT 2;
  10-21-1968
 (2 rows)
 
--- With an OFFSET clause the limit clause must NOT be pushed down
+-- With an OFFSET clause the limit clause is pushed down using ROWNUM
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: d
    ->  Foreign Scan on public.typetest1
          Output: d
-         Oracle query: SELECT /*272655bdd593a539434c24523500a6ac*/ r1."D" FROM "TYPETEST1" r1
+         Oracle query: SELECT /*23db832ed467a3671a4c0f8c1a66b4cf*/ r1."D" FROM "TYPETEST1" r1 WHERE ROWNUM >= 1 AND ROWNUM <= 2
          Oracle plan: SELECT STATEMENT
-         Oracle plan:   TABLE ACCESS FULL TYPETEST1
-(7 rows)
+         Oracle plan:   COUNT STOPKEY   (filter ROWNUM<=2)
+         Oracle plan:     FILTER    (filter ROWNUM>=1)
+         Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(9 rows)
 
 SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;
      d      

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -62,6 +62,7 @@ struct oracleSession
 	struct connEntry *connp;
 	OCIStmt *stmthp;
 	int have_nchar;
+	float oraShortVersion;
 };
 #endif
 typedef struct oracleSession oracleSession;
@@ -215,6 +216,7 @@ extern void oracleClientVersion(int *major, int *minor, int *update, int *patch,
 extern void oracleServerVersion(oracleSession *session, int *major, int *minor, int *update, int *patch, int *port_patch);
 extern void *oracleGetGeometryType(oracleSession *session);
 extern int oracleGetImportColumn(oracleSession *session, char *dblink, char *schema, char **tabname, char **colname, oraType *type, int *charlen, int *typeprec, int *typescale, int *nullable, int *key);
+extern int min_oracle_version(oracleSession *session, float refversion);
 
 /*
  * functions defined in oracle_fdw.c

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.26:1521/orcl', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -448,3 +448,18 @@ EXECUTE stmt('{varlena,nonsense}');
 EXECUTE stmt('{varlena,nonsense}');
 EXECUTE stmt('{varlena,nonsense}');
 DEALLOCATE stmt;
+
+
+/*
+ * Test LIMIT clause.
+ */
+
+-- The limit clause must be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
+SELECT d FROM typetest1 LIMIT 2;
+-- With an ORDER BY clause the limit clause must NOT be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+-- With an OFFET clause the limit clause must NOT be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
+SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.26:1521/orcl', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -449,17 +449,16 @@ EXECUTE stmt('{varlena,nonsense}');
 EXECUTE stmt('{varlena,nonsense}');
 DEALLOCATE stmt;
 
-
 /*
  * Test LIMIT clause.
  */
 
--- The limit clause must be pushed down
+-- The LIMIT clause must be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
 SELECT d FROM typetest1 LIMIT 2;
--- With an ORDER BY clause the limit clause must NOT be pushed down
+-- With an ORDER BY clause the LIMIT clause must NOT be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
 SELECT d FROM typetest1 ORDER BY d LIMIT 2;
--- With an OFFET clause the limit clause must NOT be pushed down
+-- With an OFFSET clause the limit clause must NOT be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
 SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.26:1521/orcl', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -460,6 +460,6 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
 SELECT d FROM typetest1 ORDER BY d LIMIT 2;
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 GROUP BY d LIMIT 2;
 SELECT d FROM typetest1 GROUP BY d LIMIT 2;
--- With an OFFSET clause the limit clause must NOT be pushed down
+-- With an OFFSET clause the limit clause is pushed down using ROWNUM
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
 SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -456,9 +456,10 @@ DEALLOCATE stmt;
 -- The LIMIT clause must be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
 SELECT d FROM typetest1 LIMIT 2;
--- With an ORDER BY clause the LIMIT clause must NOT be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
 SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 GROUP BY d LIMIT 2;
+SELECT d FROM typetest1 GROUP BY d LIMIT 2;
 -- With an OFFSET clause the limit clause must NOT be pushed down
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
 SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;


### PR DESCRIPTION
Add pushdown of PostgreSQL LIMIT clause translated into FETCH FIRST n ROWS ONLY on Oracle side. There is two restriction to push down the LIMIT clause, an ORDER BY clause must not be present as well as the OFFSET clause that is not supported by Oracle.