### PR TITLE
Add pushdown of PostgreSQL LIMIT clause #2

### DIFF
--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -5,7 +5,7 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 -- drop the Oracle tables if they exist
 DO

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -5,7 +5,7 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 -- drop the Oracle tables if they exist
 DO
@@ -731,4 +731,19 @@ SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
  03-15-0044 BC |     1
  10-21-1968    |     1
 (2 rows)
+
+EXPLAIN (COSTS OFF) SELECT count(*) FROM typetest1 LIMIT 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
+   ->  Aggregate
+         ->  Foreign Scan on typetest1
+               Oracle query: SELECT /*50857ae5af0c5a170837c8c56f91e583*/ '1' FROM "TYPETEST1" r1
+(4 rows)
+
+SELECT count(*) FROM typetest1 LIMIT 1;
+ count 
+-------
+     3
+(1 row)
 

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -640,3 +640,92 @@ EXECUTE stmt('{varlena,nonsense}');
 (1 row)
 
 DEALLOCATE stmt;
+/*
+ * Test pushdown of LIMIT clause.
+ */
+-- The limit clause must be pushed down (not prior Oracle 12)
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Foreign Scan on public.typetest1
+         Output: d
+         Oracle query: SELECT /*f04d370c8510559c215152b699b07ac5*/ r1."D" FROM "TYPETEST1" r1 FETCH FIRST 2 ROWS ONLY
+         Oracle plan: SELECT STATEMENT
+         Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
+         Oracle plan:     WINDOW NOSORT STOPKEY   (filter ROW_NUMBER() OVER ( ORDER BY  NULL )<=2)
+         Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(9 rows)
+
+SELECT d FROM typetest1 LIMIT 2;
+       d       
+---------------
+ 10-21-1968
+ 03-15-0044 BC
+(2 rows)
+
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Foreign Scan on public.typetest1
+         Output: d
+         Oracle query: SELECT /*e2f036b94f72638325ef6dc70ad78e76*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST FETCH FIRST 2 ROWS ONLY
+         Oracle plan: SELECT STATEMENT
+         Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
+         Oracle plan:     WINDOW SORT PUSHED RANK   (filter ROW_NUMBER() OVER ( ORDER BY "R1"."D")<=2)
+         Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(9 rows)
+
+SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+       d       
+---------------
+ 03-15-0044 BC
+ 10-21-1968
+(2 rows)
+
+-- With an OFFET clause the limit clause must NOT be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Limit
+   Output: d
+   ->  Foreign Scan on public.typetest1
+         Output: d
+         Oracle query: SELECT /*272655bdd593a539434c24523500a6ac*/ r1."D" FROM "TYPETEST1" r1
+         Oracle plan: SELECT STATEMENT
+         Oracle plan:   TABLE ACCESS FULL TYPETEST1
+(7 rows)
+
+SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;
+     d      
+------------
+ 10-21-1968
+(1 row)
+
+EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d, (count(*))
+   ->  GroupAggregate
+         Output: d, count(*)
+         Group Key: typetest1.d
+         ->  Foreign Scan on public.typetest1
+               Output: d
+               Oracle query: SELECT /*e2f036b94f72638325ef6dc70ad78e76*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST FETCH FIRST 2 ROWS ONLY
+               Oracle plan: SELECT STATEMENT
+               Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
+               Oracle plan:     WINDOW SORT PUSHED RANK   (filter ROW_NUMBER() OVER ( ORDER BY "R1"."D")<=2)
+               Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(12 rows)
+
+SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
+       d       | count 
+---------------+-------
+ 03-15-0044 BC |     1
+ 10-21-1968    |     1
+(2 rows)
+

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -5,7 +5,7 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 -- drop the Oracle tables if they exist
 DO
@@ -746,4 +746,14 @@ SELECT count(*) FROM typetest1 LIMIT 1;
 -------
      3
 (1 row)
+
+-- The LIMIT clause must not be pushed if there is a local WHERE condition
+EXPLAIN (COSTS OFF) SELECT id FROM typetest1 WHERE vc < 'u' LIMIT 1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Foreign Scan on typetest1
+         Filter: ((vc)::text < 'u'::text)
+         Oracle query: SELECT /*072b982b9aa0c38d3ad556626000d2d7*/ r1."ID", r1."VC" FROM "TYPETEST1" r1
+(4 rows)
 

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -5,7 +5,7 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 -- drop the Oracle tables if they exist
 DO
@@ -243,6 +243,7 @@ WITH upd (id, c, lb, d, ts) AS
                     ts = ts + '1 day'
    WHERE id < 3 RETURNING id + 1, c, lb, d, ts)
 SELECT * FROM upd ORDER BY id;
+WARNING:  column number 19 of foreign table "longy" does not exist in foreign Oracle table, will be replaced by NULL
  id |     c      |      lb      |     d      |                 ts                  
 ----+------------+--------------+------------+-------------------------------------
   2 | fixed chau | \xdeadbeef00 | 10-21-1968 | Tue Jan 27 15:02:54.893532 2009 PST
@@ -342,12 +343,12 @@ DELETE FROM typetest1 WHERE id = 5;
  * Test EXPLAIN support.
  */
 EXPLAIN (COSTS off) UPDATE typetest1 SET lc = current_timestamp WHERE id < 4 RETURNING id + 1;
-                                                                                                                                      QUERY PLAN                                                                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                 QUERY PLAN                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on typetest1
    Oracle statement: UPDATE "TYPETEST1" SET "LC" = :p7 WHERE "ID" = :k1 RETURNING "ID" INTO :r1
    ->  Foreign Scan on typetest1
-         Oracle query: SELECT /*15030992d3ac8035d2b16b61b10953ec*/ r1."ID", r1."C", r1."NC", r1."VC", r1."NVC", r1."LC", r1."R", r1."U", r1."LB", r1."LR", r1."B", r1."NUM", r1."FL", r1."DB", r1."D", r1."TS", r1."IDS", r1."IYM" FROM "TYPETEST1" r1 WHERE (r1."ID" < 4) FOR UPDATE
+         Oracle query: SELECT /*3f20c4dd8d9918f2fe414510067e0a60*/ r1."ID", r1."C", r1."NC", r1."VC", r1."NVC", r1."R", r1."U", r1."LB", r1."LR", r1."B", r1."NUM", r1."FL", r1."DB", r1."D", r1."TS", r1."IDS", r1."IYM" FROM "TYPETEST1" r1 WHERE (r1."ID" < 4) FOR UPDATE
 (4 rows)
 
 EXPLAIN (VERBOSE on, COSTS off) SELECT * FROM shorty;
@@ -686,28 +687,31 @@ SELECT d FROM typetest1 ORDER BY d LIMIT 2;
  10-21-1968
 (2 rows)
 
--- With an OFFET clause the limit clause must NOT be pushed down
-EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+-- With an OFFET clause the offset value is added to the limit value
+EXPLAIN (VERBOSE on, COSTS off) SELECT * FROM qtest LIMIT 1 OFFSET 2;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: d
-   ->  Foreign Scan on public.typetest1
-         Output: d
-         Oracle query: SELECT /*272655bdd593a539434c24523500a6ac*/ r1."D" FROM "TYPETEST1" r1
+   Output: id, vc, num
+   ->  Foreign Scan on public.qtest
+         Output: id, vc, num
+         Oracle query: SELECT /*e571dec394b1d567b88b73fb3b4e6786*/ r1."ID", r1."SUBSTR(VC,1,3)", r1."NUM" FROM (SELECT id, SUBSTR(vc, 1, 3), num FROM typetest1) r1 FETCH FIRST 1+2 ROWS ONLY
          Oracle plan: SELECT STATEMENT
-         Oracle plan:   TABLE ACCESS FULL TYPETEST1
-(7 rows)
+         Oracle plan:   VIEW    (filter "from$_subquery$_003"."rowlimit_$$_rownumber"<=3)
+         Oracle plan:     WINDOW NOSORT STOPKEY   (filter ROW_NUMBER() OVER ( ORDER BY  NULL )<=3)
+         Oracle plan:       TABLE ACCESS FULL TYPETEST1
+(9 rows)
 
-SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;
-     d      
-------------
- 10-21-1968
+SELECT * FROM qtest LIMIT 1 OFFSET 2;
+ id | vc  |   num   
+----+-----+---------
+  4 | sho | 0.00000
 (1 row)
 
+-- When a GROUP BY clause is present the LIMIT clause is not pushed
 EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: d, (count(*))
    ->  GroupAggregate
@@ -715,12 +719,11 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIM
          Group Key: typetest1.d
          ->  Foreign Scan on public.typetest1
                Output: d
-               Oracle query: SELECT /*e2f036b94f72638325ef6dc70ad78e76*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST FETCH FIRST 2 ROWS ONLY
+               Oracle query: SELECT /*145d52f5de38a843e3af04dc11eeb80c*/ r1."D" FROM "TYPETEST1" r1 ORDER BY r1."D" ASC NULLS LAST
                Oracle plan: SELECT STATEMENT
-               Oracle plan:   VIEW    (filter "from$_subquery$_002"."rowlimit_$$_rownumber"<=2)
-               Oracle plan:     WINDOW SORT PUSHED RANK   (filter ROW_NUMBER() OVER ( ORDER BY "R1"."D")<=2)
-               Oracle plan:       TABLE ACCESS FULL TYPETEST1
-(12 rows)
+               Oracle plan:   SORT ORDER BY
+               Oracle plan:     TABLE ACCESS FULL TYPETEST1
+(11 rows)
 
 SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
        d       | count 

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -943,9 +943,10 @@ oracleGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid
 		fdwState->order_clause = orderedquery.data;
 
 	/*
-	 * Add LIMIT (FETCH N FIRST ROW ONLY) expression if oracle version >= 12.
+	 * Add LIMIT (FETCH N FIRST ROW ONLY) expression if oracle version >= 12
+	 * and if there is not local WHERE condition.
 	 */
-	if (min_oracle_version(fdwState->session, 12, 0))
+	if (min_oracle_version(fdwState->session, 12, 0) && list_length(fdwState->local_conds) == 0)
 	{
 		if ((list_length(root->canon_pathkeys) <= 1 && !root->cte_plan_ids)
 				||  (list_length(root->parse->rtable) == 1) )

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -754,20 +754,10 @@ deparseLimit(PlannerInfo *root, struct OracleFdwState *fdwState, RelOptInfo *bas
 			char *offset_val;
 
 			appendStringInfoString(&limit_clause, " FETCH FIRST ");
-			limit_val = deparseExpr(
-						fdwState->session, baserel,
-						(Expr *) root->parse->limitCount,
-						fdwState->oraTable,
-						&(fdwState->params)
-					);
-			if (root->parse->limitOffset != NULL)
+			limit_val = datumToString(((Const *) root->parse->limitCount)->constvalue, ((Const *) root->parse->limitCount)->consttype);
+			if (IsA(root->parse->limitOffset, Const) && !((Const *) root->parse->limitOffset)->constisnull)
 			{
-				offset_val = deparseExpr(
-							fdwState->session, baserel,
-							(Expr *) root->parse->limitOffset,
-							fdwState->oraTable,
-							&(fdwState->params)
-						);
+				offset_val = datumToString(((Const *) root->parse->limitOffset)->constvalue, ((Const *) root->parse->limitOffset)->consttype);
 				appendStringInfo(&limit_clause, "%s+%s", limit_val, offset_val);
 			}
 			else

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -246,6 +246,7 @@ struct OracleFdwState {
 	unsigned int prefetch;         /* number of rows to prefetch */
 	char *order_clause;            /* for sort-pushdown */
 	char *where_clause;            /* deparsed where clause */
+	char *limit_clause;            /* deparsed limit clause */
 
 	/*
 	 * Restriction clauses, divided into safe and unsafe to pushdown subsets.
@@ -387,6 +388,7 @@ static void appendReturningClause(StringInfo sql, struct OracleFdwState *fdwStat
 static char *fold_case(char *name, fold_t foldcase, int collation);
 #endif  /* IMPORT_API */
 static oraIsoLevel getIsolationLevel(const char *isolation_level);
+char * deparseLimit(PlannerInfo *root, struct OracleFdwState *fdwState, RelOptInfo *baserel);
 
 #define REL_ALIAS_PREFIX    "r"
 /* Handy macro to add relation name qualification */
@@ -733,6 +735,69 @@ _PG_init(void)
 }
 
 /*
+ * Deparse LIMIT clause translated for ORACLE into FETCH FIRST N ROWS ONLY
+ * If OFFSET is set then do not append clause at all, the limit +offset
+ * will be applied localy.
+ */
+char *
+deparseLimit(PlannerInfo *root, struct OracleFdwState *fdwState, RelOptInfo *baserel)
+{
+	StringInfoData limit_clause;
+
+	initStringInfo(&limit_clause);
+
+	if (root->parse->limitCount != NULL && root->parse->limitOffset == NULL)
+	{
+		if (IsA(root->parse->limitCount, Const) && !((Const *) root->parse->limitCount)->constisnull)
+		{
+			int limit_at_end = false;
+
+			/*
+			 * we must be sure that there is no ORDER BY clause that
+			 * appears after the LIMIT clause otherwise we will have
+			 * wrong results.
+			 */
+			if (root->parse->sortClause != NULL)
+			{
+				ListCell   *lc;
+				foreach (lc, root->processed_tlist)
+				{
+					Node *ptl = (Node *) lfirst(lc);
+					if (IsA(ptl, TargetEntry))
+					{
+						TargetEntry *tge = (TargetEntry *) ptl;
+						/* Aggregate function are pushed down so it is safe to continue */
+						if (IsA(tge->expr, Aggref))
+							continue;
+						if (tge->ressortgroupref > 0 &&
+								tge->resorigcol == 0 &&
+								(tge->resname &&
+									strcmp(tge->resname, "agg_target") != 0)
+						)
+							limit_at_end = true;
+					}
+				}
+			}
+			if (!limit_at_end)
+			{
+				char *limit_val;
+
+				appendStringInfoString(&limit_clause, " FETCH FIRST ");
+				limit_val = deparseExpr(
+							fdwState->session, baserel,
+							(Expr *) root->parse->limitCount,
+							fdwState->oraTable,
+							&(fdwState->params)
+						);
+				appendStringInfo(&limit_clause, "%s", limit_val);
+				appendStringInfoString(&limit_clause, " ROWS ONLY");
+			}
+		}
+	}
+	return limit_clause.data;
+}
+
+/*
  * oracleGetForeignRelSize
  * 		Get an OracleFdwState for this foreign scan.
  * 		Construct the remote SQL query.
@@ -771,11 +836,6 @@ oracleGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntable
 								&(fdwState->local_conds),
 								&(fdwState->remote_conds)
 							);
-
-	/* release Oracle session (will be cached) */
-	pfree(fdwState->session);
-	fdwState->session = NULL;
-
 	/* use a random "high" value for cost */
 	fdwState->startup_cost = 10000.0;
 
@@ -889,6 +949,23 @@ oracleGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid
 	/* set order clause */
 	if (usable_pathkeys != NIL)
 		fdwState->order_clause = orderedquery.data;
+
+	/*
+	 * Add LIMIT (FETCH N FIRST ROW ONLY) expression if not OFFSET clause
+	 * is used and that oracle version >= 12.
+	 */
+	if (root->parse->limitOffset == NULL && min_oracle_version(fdwState->session, 12, 0))
+	{
+		if ((list_length(root->canon_pathkeys) <= 1 && !root->cte_plan_ids)
+				||  (list_length(root->parse->rtable) == 1) )
+		{
+			fdwState->limit_clause = deparseLimit(root, fdwState, baserel);
+		}
+	}
+
+	/* release Oracle session (will be cached) */
+	pfree(fdwState->session);
+	fdwState->session = NULL;
 
 	/* add the only path */
 	add_path(baserel,
@@ -2838,6 +2915,10 @@ char
 	/* append ORDER BY clause if all its expressions can be pushed down */
 	if (fdwState->order_clause)
 		appendStringInfo(&query, " ORDER BY%s", fdwState->order_clause);
+
+	/* append LIMIT clause if there is no order by clause */
+	if (fdwState->limit_clause)
+		appendStringInfo(&query, "%s", fdwState->limit_clause);
 
 	/* append FOR UPDATE if if the scan is for a modification */
 	if (modify)

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -773,9 +773,12 @@ deparseLimit(PlannerInfo *root, struct OracleFdwState *fdwState, RelOptInfo *bas
 			else
 				appendStringInfo(&limit_clause, "%s", limit_val);
 			appendStringInfoString(&limit_clause, " ROWS ONLY");
+
+			return limit_clause.data;
 		}
 	}
-	return limit_clause.data;
+
+	return NULL;
 }
 
 /*

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -217,6 +217,7 @@ extern void oracleClientVersion(int *major, int *minor, int *update, int *patch,
 extern void oracleServerVersion(oracleSession *session, int *major, int *minor, int *update, int *patch, int *port_patch);
 extern void *oracleGetGeometryType(oracleSession *session);
 extern int oracleGetImportColumn(oracleSession *session, char *dblink, char *schema, char **tabname, char **colname, oraType *type, int *charlen, int *typeprec, int *typescale, int *nullable, int *key);
+extern int min_oracle_version(oracleSession *session, int major, int minor);
 
 /*
  * functions defined in oracle_fdw.c

--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -3267,3 +3267,20 @@ setNullGeometry(oracleSession *session, ora_geometry *geom)
 	geom->geometry = null_geometry.geometry;
 	geom->indicator = null_geometry.indicator;
 }
+
+/*
+ * min_oracle_version:
+ * 		Verify that the Oracle server version correspond
+ * 		to a minimum major and minor number.
+ */
+int
+min_oracle_version(oracleSession *session, int major, int minor)
+{
+	if (session->server_version[0] > major
+			|| (session->server_version[0] == major
+				&& session->server_version[1] > minor))
+	       return 1;
+
+	return 0;
+}
+

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -448,3 +448,19 @@ EXECUTE stmt('{varlena,nonsense}');
 EXECUTE stmt('{varlena,nonsense}');
 EXECUTE stmt('{varlena,nonsense}');
 DEALLOCATE stmt;
+
+
+/*
+ * Test pushdown of LIMIT clause.
+ */
+
+-- The limit clause must be pushed down (not prior Oracle 12)
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
+SELECT d FROM typetest1 LIMIT 2;
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+SELECT d FROM typetest1 ORDER BY d LIMIT 2;
+-- With an OFFET clause the limit clause must NOT be pushed down
+EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
+SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;
+EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
+SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -465,3 +465,5 @@ SELECT * FROM qtest LIMIT 1 OFFSET 2;
 -- When a GROUP BY clause is present the LIMIT clause is not pushed
 EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
 SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
+EXPLAIN (COSTS OFF) SELECT count(*) FROM typetest1 LIMIT 1;
+SELECT count(*) FROM typetest1 LIMIT 1;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -459,8 +459,9 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 2;
 SELECT d FROM typetest1 LIMIT 2;
 EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 ORDER BY d LIMIT 2;
 SELECT d FROM typetest1 ORDER BY d LIMIT 2;
--- With an OFFET clause the limit clause must NOT be pushed down
-EXPLAIN (VERBOSE on, COSTS off) SELECT d FROM typetest1 LIMIT 1 OFFSET 1;
-SELECT d FROM typetest1 ORDER BY d LIMIT 1 OFFSET 1;
+-- With an OFFET clause the offset value is added to the limit value
+EXPLAIN (VERBOSE on, COSTS off) SELECT * FROM qtest LIMIT 1 OFFSET 2;
+SELECT * FROM qtest LIMIT 1 OFFSET 2;
+-- When a GROUP BY clause is present the LIMIT clause is not pushed
 EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
 SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '//192.168.1.34:1521/orcl', isolation_level 'read_committed', nchar 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true');
 
 CREATE USER MAPPING FOR PUBLIC SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -467,3 +467,5 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT d, count(*) FROM typetest1 GROUP BY d LIM
 SELECT d, count(*) FROM typetest1 GROUP BY d LIMIT 2;
 EXPLAIN (COSTS OFF) SELECT count(*) FROM typetest1 LIMIT 1;
 SELECT count(*) FROM typetest1 LIMIT 1;
+-- The LIMIT clause must not be pushed if there is a local WHERE condition
+EXPLAIN (COSTS OFF) SELECT id FROM typetest1 WHERE vc < 'u' LIMIT 1;


### PR DESCRIPTION
The clause is translated into FETCH FIRST n ROWS ONLY in remote query sent to Oracle. There is two restrictions to the push down of the LIMIT clause, an OFFSET clause must not be present in the query and the minimum Oracle version must not be 12c.