### PR TITLE
Fix a function return type

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -6629,7 +6629,7 @@ fold_case(char *name, fold_t foldcase, int collation)
  *		Converts Oracle isolation level string to oraIsoLevel.
  *      Throws an error for invalid values.
  */
-unsigned int
+oraIsoLevel
 getIsolationLevel(const char *isolation_level)
 {
 	oraIsoLevel val = 0;


### PR DESCRIPTION
hi

When I build in Solaris, the following error occurred
```
"oracle_fdw.c", line 372: warning: static function called but not defined: getIsolationLevel()
cc: acomp failed for oracle_fdw.c
gmake: *** [oracle_fdw.o] Error 2
"oracle_fdw.c", line 372: warning: static function called but not defined: getIsolationLevel()
cc: acomp failed for oracle_fdw.c
gmake: *** [oracle_fdw.o] Error 2
```

I think this is because the declaration and implementation of the function use different return types. 
In general, this is allowed, but this will cause build error on Solaris.
I think this patch can solve this problem.