### PR TITLE
fix build with Visual Studio 2019

### DIFF
--- a/msvc/oracle_msvc.c
+++ b/msvc/oracle_msvc.c
@@ -53,4 +53,4 @@ oracleDelayLoadFailureHook(unsigned dliNotify, PDelayLoadInfo pdli)
 	return 0;
 }
 
-PfnDliHook __pfnDliFailureHook2 = oracleDelayLoadFailureHook;
+ExternC const PfnDliHook __pfnDliFailureHook2 = oracleDelayLoadFailureHook;


### PR DESCRIPTION
Hello,

When I built oracle_fdw using PostgreSQL 14 and Visual Studio 2019, I encountered the following error.
```
msbuild oracle_fdw.sln /p:Configuration=Release ^
      /p:Platform=x64 ^
      /p:OracleClient="C:\instantclient_21_3" ^
      /p:PostgreSQL="C:\Program Files\PostgreSQL\14"

"E:\kato\oracle_fdw\msvc\oracle_fdw.sln" (default target) (1) ->
"E:\kato\oracle_fdw\msvc\oracle_fdw.vcxproj" (default target) (2) ->
(ClCompile target) ->
  E:\kato\oracle_fdw\msvc\oracle_msvc.c(56,12): error C2373: '__pfnDliFailureHook2': redefinition; different type modif
iers [E:\kato\oracle_fdw\msvc\oracle_fdw.vcxproj]

    5 Warning(s)
    1 Error(s)
```
I looked into ms documents and add "ExternC const" before PfnDliHook and build was successful.

https://docs.microsoft.com/en-us/cpp/build/reference/understanding-the-helper-function?view=msvc-170#structure-and-constant-definitions

Do you need this fix?