### PR TITLE
Updated column option "key" check.

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -1461,7 +1461,7 @@ oracleAddForeignUpdateTargets(
 					has_key = true;
 				}
 			}
-			else
+			else if (strcmp(def->defname, OPT_STRIP_ZEROS) != 0)
 			{
 				elog(ERROR, "impossible column option \"%s\"", def->defname);
 			}


### PR DESCRIPTION
If the key option and strip_zeros option are used at the same time in the foreign table definition, an error occurs when executing the DELETE statement. This patch fixes the check part of the key option.

ex)
postgres=> CREATE FOREIGN TABLE opt1(c1 NUMERIC OPTIONS (key 'true'), c2 VARCHAR(10) OPTIONS (strip_zeros 'true'), c3 VARCHAR(10)) SERVER o19c1 OPTIONS (table 'OPT1');
CREATE FOREIGN TABLE
postgres=> DELETE FROM opt1 WHERE c1=100;
ERROR:  impossible column option "strip_zeros"