### PR TITLE
Add support for already quoted strings.

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -544,7 +544,7 @@ oracle_fdw_validator(PG_FUNCTION_ARGS)
 		if (strcmp(def->defname, OPT_TABLE) == 0)
 		{
 			char *val = strVal(def->arg);
-			if (strchr(val, '"') != NULL)
+			if (val[0] == '"' || val[strlen(val) - 1] == '"')
 				ereport(ERROR,
 						(errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
 						errmsg("invalid value for option \"%s\"", def->defname),

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -540,6 +540,17 @@ oracle_fdw_validator(PG_FUNCTION_ARGS)
 						errhint("Double quotes are not allowed in the schema name.")));
 		}
 
+		/* check valid values for "table" */
+		if (strcmp(def->defname, OPT_TABLE) == 0)
+		{
+			char *val = strVal(def->arg);
+			if (strchr(val, '"') != NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+						errmsg("invalid value for option \"%s\"", def->defname),
+						errhint("Double quotes are not allowed in the table name.")));
+		}
+
 		/* check valid values for max_long */
 		if (strcmp(def->defname, OPT_MAX_LONG) == 0)
 		{

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -540,17 +540,6 @@ oracle_fdw_validator(PG_FUNCTION_ARGS)
 						errhint("Double quotes are not allowed in the schema name.")));
 		}
 
-		/* check valid values for "table" */
-		if (strcmp(def->defname, OPT_TABLE) == 0)
-		{
-			char *val = strVal(def->arg);
-			if (val[0] == '"' || val[strlen(val) - 1] == '"')
-				ereport(ERROR,
-						(errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
-						errmsg("invalid value for option \"%s\"", def->defname),
-						errhint("Double quotes are not allowed in the table name.")));
-		}
-
 		/* check valid values for max_long */
 		if (strcmp(def->defname, OPT_MAX_LONG) == 0)
 		{

--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -2833,6 +2833,15 @@ char
 		result[size] = '\0';
 		return result;
 	}
+
+	/* if "string" is already quoted, return a copy */
+	if (string[0] == '"' && string[size-1] == '"')
+	{
+		result = oracleAlloc(size + 1);
+		memcpy(result, string, size);
+		result[size] = '\0';
+		return result;
+	}
 		
 	if (quote)
 	{


### PR DESCRIPTION
Hello, thank you for developing the great software.

This pull request modifies the handling of the "table" option. The current version allows double quotation for the "table" option, but an error will occur if it is already quoted.

postgres => CREATE FOREIGN TABLE data1 (c1 NUMERIC, c2 VARCHAR (10)) SERVER o19c1 OPTIONS (table'"DATA1"');
CREATE FOREIGN TABLE
postgres => SELECT COUNT (*) FROM data1;
ERROR: error describing remote table: OCIStmtExecute failed to describe table
DETAIL: ORA-01741: illegal zero-length identifier

The pull request returns the string specified in the "table" option if it has already been quoted.