### PR TITLE
Discover include and lib directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,15 @@ DATA = oracle_fdw--1.2.sql oracle_fdw--1.0--1.1.sql oracle_fdw--1.1--1.2.sql
 DOCS = README.oracle_fdw
 REGRESS = oracle_fdw oracle_gis oracle_import oracle_join
 
+FIND_INCLUDE != ls -d /usr/include/oracle/*/client64 /usr/include/oracle/*/client
+FIND_LIBDIRS != ls -d /usr/lib/oracle/*/client64/lib /usr/lib/oracle/*/client/lib
+
+FIND_CPPFLAGS = $(foreach DIR,$(FIND_INCLUDE),-I$(DIR))
+FIND_LDFLAGS = $(foreach DIR,$(FIND_LIBDIRS),-L$(DIR))
+
 # add include and library paths for both Instant Client and regular Client
-PG_CPPFLAGS = -I"$(ORACLE_HOME)/sdk/include" -I"$(ORACLE_HOME)/oci/include" -I"$(ORACLE_HOME)/rdbms/public" -I"$(ORACLE_HOME)/" -I/usr/include/oracle/21/client64 -I/usr/include/oracle/19.15/client64 -I/usr/include/oracle/19.14/client64 -I/usr/include/oracle/19.12/client64 -I/usr/include/oracle/19.12/client -I/usr/include/oracle/19.11/client64 -I/usr/include/oracle/19.11/client -I/usr/include/oracle/19.10/client64 -I/usr/include/oracle/19.10/client -I/usr/include/oracle/19.9/client -I/usr/include/oracle/19.9/client64 -I/usr/include/oracle/19.8/client -I/usr/include/oracle/19.8/client64 -I/usr/include/oracle/19.6/client -I/usr/include/oracle/19.6/client64 -I/usr/include/oracle/19.3/client -I/usr/include/oracle/19.3/client64 -I/usr/include/oracle/18.5/client -I/usr/include/oracle/18.5/client64 -I/usr/include/oracle/18.3/client -I/usr/include/oracle/18.3/client64 -I/usr/include/oracle/12.2/client -I/usr/include/oracle/12.2/client64 -I/usr/include/oracle/12.1/client -I/usr/include/oracle/12.1/client64 -I/usr/include/oracle/11.2/client -I/usr/include/oracle/11.2/client64
-SHLIB_LINK = -L"$(ORACLE_HOME)/" -L"$(ORACLE_HOME)/bin" -L"$(ORACLE_HOME)/lib" -L"$(ORACLE_HOME)/lib/amd64" -l$(ORACLE_SHLIB) -L/usr/lib/oracle/21/client64/lib -L/usr/lib/oracle/19.15/client64/lib -L/usr/lib/oracle/19.14/client64/lib -L/usr/lib/oracle/19.12/client64/lib -L/usr/lib/oracle/19.12/client/lib -L/usr/lib/oracle/19.11/client64/lib -L/usr/lib/oracle/19.11/client/lib -L/usr/lib/oracle/19.10/client64/lib -L/usr/lib/oracle/19.10/client/lib -L/usr/lib/oracle/19.9/client/lib -L/usr/lib/oracle/19.9/client64/lib -L/usr/lib/oracle/19.8/client/lib -L/usr/lib/oracle/19.8/client64/lib -L/usr/lib/oracle/19.6/client/lib -L/usr/lib/oracle/19.6/client64/lib -L/usr/lib/oracle/19.3/client/lib -L/usr/lib/oracle/19.3/client64/lib -L/usr/lib/oracle/18.5/client/lib -L/usr/lib/oracle/18.5/client64/lib -L/usr/lib/oracle/18.3/client/lib -L/usr/lib/oracle/18.3/client64/lib -L/usr/lib/oracle/12.2/client/lib -L/usr/lib/oracle/12.2/client64/lib -L/usr/lib/oracle/12.1/client/lib -L/usr/lib/oracle/12.1/client64/lib -L/usr/lib/oracle/11.2/client/lib -L/usr/lib/oracle/11.2/client64/lib
+PG_CPPFLAGS = -I"$(ORACLE_HOME)/sdk/include" -I"$(ORACLE_HOME)/oci/include" -I"$(ORACLE_HOME)/rdbms/public" -I"$(ORACLE_HOME)/" $(FIND_CPPFLAGS)
+SHLIB_LINK = -L"$(ORACLE_HOME)/" -L"$(ORACLE_HOME)/bin" -L"$(ORACLE_HOME)/lib" -L"$(ORACLE_HOME)/lib/amd64" -l$(ORACLE_SHLIB) $(FIND_LDFLAGS)
 
 # don't build LLVM byte code
 override with_llvm := no


### PR DESCRIPTION
It is entirely possible that I overlooked a path somewhere in the long list that looks different from most of the others. This is also completely untested; I do not have a Linux system that I could try it on. If only there was an Instant Client for FreeBSD ...

There will probably be only `client` or only `client64` directories on any given system, and the `ls` will report that the other variant of the path is missing. It does not look like make cares enough to abort, though; a simple

```
dump:
        @echo $(FIND_CPPFLAGS)
```

still runs even after the error message.

May fix #538.