### PR TITLE
Fix: Skip LIMIT pushdown when SELECT FOR UPDATE was used

### DIFF
--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -811,6 +811,22 @@ SELECT id FROM typetest1 WHERE vc < 'u' LIMIT 1;
   3
 (1 row)
 
+-- no LIMIT push-down in SELECT FOR UPDATE queries
+EXPLAIN (COSTS OFF) SELECT id FROM typetest1 LIMIT 1 FOR UPDATE;
+                                                                                                                       QUERY PLAN                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  LockRows
+         ->  Foreign Scan on typetest1
+               Oracle query: SELECT /*c1ce793ab752187b*/ r1."ID", r1."C", r1."NC", r1."VC", r1."NVC", r1."LC", r1."R", r1."U", r1."LB", r1."LR", r1."B", r1."NUM", r1."FL", r1."DB", r1."D", r1."TS", r1."IDS", r1."IYM" FROM "TYPETEST1" r1 FOR UPDATE
+(4 rows)
+
+SELECT id FROM typetest1 LIMIT 1 FOR UPDATE;
+ id 
+----
+  1
+(1 row)
+
 /* test ANALYZE */
 ANALYZE typetest1;
 ANALYZE longy;

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -2893,6 +2893,7 @@ char
 		appendStringInfo(&query, " ORDER BY%s", fdwState->order_clause);
 
 	/* append FETCH FIRST n ROWS ONLY if the LIMIT can be pushed down */
+	/* skip LIMIT when SELECT FOR UPDATE is used */
 	if (fdwState->limit_clause)
 		appendStringInfo(&query, " %s", fdwState->limit_clause);
 

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -520,6 +520,9 @@ SELECT 12 - count(*) FROM typetest1 LIMIT 1;
 -- no LIMIT push-down if there is a local WHERE condition
 EXPLAIN (COSTS OFF) SELECT id FROM typetest1 WHERE vc < 'u' LIMIT 1;
 SELECT id FROM typetest1 WHERE vc < 'u' LIMIT 1;
+-- no LIMIT push-down in SELECT FOR UPDATE queries
+EXPLAIN (COSTS OFF) SELECT id FROM typetest1 LIMIT 1 FOR UPDATE;
+SELECT id FROM typetest1 LIMIT 1 FOR UPDATE;
 
 /* test ANALYZE */
 


### PR DESCRIPTION
In Oracle, using FETCH FIRST along with FOR UPDATE results in error "ORA-02014: cannot select FOR UPDATE from view with DISTINCT, GROUP BY, etc."

Ignoring LIMIT is not optimal: it can result in too many rows being locked, but I think it's better than failing outright.
