### PR TITLE
Supporting return the whole-row

### DIFF
--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -402,9 +402,7 @@ SELECT id FROM typetest1 WHERE vc = ANY ('{zzzzz}'::name[]);
 ----
 (0 rows)
 
-/*
- * Test INSERT ... RETURNING
- */
+-- test returning a whole row
 INSERT INTO returningtest (id, c, nc, vc) VALUES (
    1,
    'fixed char',
@@ -422,6 +420,18 @@ INSERT INTO returningtest (id) VALUES (
  returningtest 
 ---------------
  (2,,,)
+(1 row)
+
+UPDATE returningtest SET c = 'updated' WHERE id = 1 RETURNING returningtest;
+             returningtest             
+---------------------------------------
+ (1,"updated   ","nat'l char",varlena)
+(1 row)
+
+DELETE FROM returningtest WHERE id = 1 RETURNING returningtest;
+             returningtest             
+---------------------------------------
+ (1,"updated   ","nat'l char",varlena)
 (1 row)
 
 /*

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -29,6 +29,13 @@ EXCEPTION
    WHEN OTHERS THEN
       NULL;
 END;$$;
+DO
+$$BEGIN
+   SELECT oracle_execute('oracle', 'DROP TABLE scott.returningtest PURGE');
+EXCEPTION
+   WHEN OTHERS THEN
+      NULL;
+END;$$;
 SELECT oracle_execute(
           'oracle',
           E'CREATE TABLE scott.typetest1 (\n'
@@ -78,6 +85,20 @@ SELECT oracle_execute(
           E'CREATE TABLE scott.gis (\n'
           '   id  NUMBER(5) PRIMARY KEY,\n'
           '   g   MDSYS.SDO_GEOMETRY\n'
+          ') SEGMENT CREATION IMMEDIATE'
+       );
+ oracle_execute 
+----------------
+ 
+(1 row)
+
+SELECT oracle_execute(
+          'oracle',
+          E'CREATE TABLE scott.returningtest (\n'
+          '   id  NUMBER(5) PRIMARY KEY,\n'
+          '   c   CHAR(10 CHAR),\n'
+          '   nc  NCHAR(10),\n'
+          '   vc  VARCHAR2(10 CHAR)\n'
           ') SEGMENT CREATION IMMEDIATE'
        );
  oracle_execute 
@@ -190,6 +211,12 @@ CREATE FOREIGN TABLE typetest2 (
    ts2 timestamp without time zone,
    ts3 date
 ) SERVER oracle OPTIONS (table 'TYPETEST2');
+CREATE FOREIGN TABLE returningtest (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   c   character(10),
+   nc  character(10),
+   vc  character varying(10)
+) SERVER oracle OPTIONS (table 'RETURNINGTEST');
 /*
  * INSERT some rows into "typetest1".
  */
@@ -374,6 +401,28 @@ SELECT id FROM typetest1 WHERE vc = ANY ('{zzzzz}'::name[]);
  id 
 ----
 (0 rows)
+
+/*
+ * Test INSERT ... RETURNING
+ */
+INSERT INTO returningtest (id, c, nc, vc) VALUES (
+   1,
+   'fixed char',
+   'nat''l char',
+   'varlena'
+) RETURNING id, c, nc, vc;
+ id |     c      |     nc     |   vc    
+----+------------+------------+---------
+  1 | fixed char | nat'l char | varlena
+(1 row)
+
+INSERT INTO returningtest (id) VALUES (
+   2
+) RETURNING returningtest;
+ returningtest 
+---------------
+ (2,,,)
+(1 row)
 
 /*
  * Test "strip_zeros" column option.

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -323,22 +323,18 @@ DELETE FROM typetest1 WHERE FALSE;
 UPDATE shorty SET c = NULL WHERE FALSE RETURNING *;
 -- test deparsing of ScalarArrayOpExpr where the RHS has different element type than the LHS
 SELECT id FROM typetest1 WHERE vc = ANY ('{zzzzz}'::name[]);
-
-
-/*
- * Test INSERT ... RETURNING
- */
-
+-- test returning a whole row
 INSERT INTO returningtest (id, c, nc, vc) VALUES (
    1,
    'fixed char',
    'nat''l char',
    'varlena'
 ) RETURNING id, c, nc, vc;
-
 INSERT INTO returningtest (id) VALUES (
    2
 ) RETURNING returningtest;
+UPDATE returningtest SET c = 'updated' WHERE id = 1 RETURNING returningtest;
+DELETE FROM returningtest WHERE id = 1 RETURNING returningtest;
 
 
 /*


### PR DESCRIPTION
Hi.
I'm posting on behalf of jopoly as a co-worker according to the company's policy.

This fixes #568

```
CREATE FOREIGN TABLE tbl1 (
  c1 int,
  c2 character(10),
  c3 character(10)
) SERVER oracle_srv (table 'TBL1');

INSERT INTO tbl1 (c1, c2) VALUES (1, 'aaa') RETURNING c1, c2;
 c1 |  c2 
----+-----
  1 | aaa 
(1 row)

-- RETURNING the whole row
INSERT INTO tbl1 (c1, c2) VALUES (1, 'aaa') RETURNING tb1;
   tb1
---------
(1, aaa,)
(1 row)
```
