### PR TITLE
Support generated column when UPDATE

### DIFF
--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -968,6 +968,7 @@ SELECT oracle_close_connections();
 --------------------------
  
 (1 row)
+
 RESET timezone;
 /*
  * Test generated columns

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -29,6 +29,13 @@ EXCEPTION
    WHEN OTHERS THEN
       NULL;
 END;$$;
+DO
+$$BEGIN
+   SELECT oracle_execute('oracle', 'DROP TABLE scott.gloc1 PURGE');
+EXCEPTION
+   WHEN OTHERS THEN
+      NULL;
+END;$$;
 SELECT oracle_execute(
           'oracle',
           E'CREATE TABLE scott.typetest1 (\n'
@@ -128,6 +135,19 @@ SELECT oracle_execute(
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC''),\n'
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC'')\n'
           ')'
+       );
+ oracle_execute 
+----------------
+ 
+(1 row)
+
+-- initial data for gloc1
+SELECT oracle_execute(
+          'oracle',
+          E'CREATE TABLE scott.gloc1 (\n'
+          '   a  NUMBER(5) PRIMARY KEY,\n'
+          '   b  NUMBER(5)\n'
+          ') SEGMENT CREATION IMMEDIATE'
        );
  oracle_execute 
 ----------------
@@ -948,4 +968,39 @@ SELECT oracle_close_connections();
 --------------------------
  
 (1 row)
+RESET timezone;
+/*
+ * Test generated columns
+ */
+create foreign table grem1 (
+  a int OPTIONS (key 'yes'),
+  b int generated always as (a * 2) stored)
+  server oracle options(table 'GLOC1');
+explain (costs off)
+insert into grem1 (a) values (1), (2);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Insert on grem1
+   Oracle statement: INSERT INTO "GLOC1" ("A", "B") VALUES (:p1, :p2)
+   ->  Values Scan on "*VALUES*"
+(3 rows)
+
+insert into grem1 (a) values (1), (2);
+explain (costs off)
+update grem1 set a = 22 where a = 2;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Update on grem1
+   Oracle statement: UPDATE "GLOC1" SET "A" = :p1, "B" = :p2 WHERE "A" = :k1
+   ->  Foreign Scan on grem1
+         Oracle query: SELECT /*43ad2464cc16ab0b*/ r1."A", r1."B" FROM "GLOC1" r1 WHERE (r1."A" = 2) FOR UPDATE
+(4 rows)
+
+update grem1 set a = 22 where a = 2;
+select a, b from grem1;
+ a  | b  
+----+----
+  1 |  2
+ 22 | 44
+(2 rows)
 

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -1568,11 +1568,13 @@ oraclePlanForeignModify(PlannerInfo *root, ModifyTable *plan, Index resultRelati
 	updated_cols = perminfo->updatedCols;
 #else
 	check_user = rte->checkAsUser;
-#if PG_VERSION_NUM >= 90500
+#if PG_VERSION_NUM >= 120000
+	updated_cols = bms_union(rte->updatedCols, rte->extraUpdatedCols);
+#elif PG_VERSION_NUM >= 90500
 	updated_cols = rte->updatedCols;
 #else
 	updated_cols = bms_copy(rte->modifiedCols);
-#endif  /* PG_VERSION_NUM >= 90500 */
+#endif  /* PG_VERSION_NUM >= 120000 */
 #endif  /* PG_VERSION_NUM >= 160000 */
 
 #if PG_VERSION_NUM >= 90500

--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -94,7 +94,9 @@
 #include "optimizer/optimizer.h"
 #include "access/heapam.h"
 #endif
-#if PG_VERSION_NUM >= 150002
+#if (PG_VERSION_NUM >= 130010 && PG_VERSION_NUM < 140000) || \
+	(PG_VERSION_NUM >= 140007 && PG_VERSION_NUM < 150000) || \
+	(PG_VERSION_NUM >= 150002)
 #include "optimizer/inherit.h"
 #endif
 
@@ -1574,7 +1576,9 @@ oraclePlanForeignModify(PlannerInfo *root, ModifyTable *plan, Index resultRelati
 	}
 #else
 	check_user = rte->checkAsUser;
-#if PG_VERSION_NUM >= 150002
+#if (PG_VERSION_NUM >= 130010 && PG_VERSION_NUM < 140000) || \
+	(PG_VERSION_NUM >= 140007 && PG_VERSION_NUM < 150000) || \
+	(PG_VERSION_NUM >= 150002 && PG_VERSION_NUM < 160000)
 	if (root->parse->commandType != CMD_UPDATE)
 	{
 		updated_cols = bms_copy(rte->updatedCols);
@@ -1585,10 +1589,14 @@ oraclePlanForeignModify(PlannerInfo *root, ModifyTable *plan, Index resultRelati
 	updated_cols = rte->updatedCols;
 #else
 	updated_cols = bms_copy(rte->modifiedCols);
-#endif  /* PG_VERSION_NUM >= 150002 */
+#endif  /* (PG_VERSION_NUM >= 130010 && PG_VERSION_NUM < 140000) || \
+		   (PG_VERSION_NUM >= 140007 && PG_VERSION_NUM < 150000) || \
+		   (PG_VERSION_NUM >= 150002 && PG_VERSION_NUM < 160000) */
 #endif  /* PG_VERSION_NUM >= 160000 */
 
-#if PG_VERSION_NUM >= 150002
+#if (PG_VERSION_NUM >= 130010 && PG_VERSION_NUM < 140000) || \
+	(PG_VERSION_NUM >= 140007 && PG_VERSION_NUM < 150000) || \
+	(PG_VERSION_NUM >= 150002)
 	else
 	{
 		RelOptInfo *relOtp = find_base_rel(root, resultRelation);


### PR DESCRIPTION
Hi.
I'm posting on behalf of jopoly as a co-worker according to the company's policy.
This fixes https://github.com/laurenz/oracle_fdw/issues/568
Solves the problem of generated columns like below.

```
CREATE FOREIGN TABLE tbl1 (
  c1 int,
  c2 character(10),
  c3 character(10)
) SERVER oracle_srv (table 'TBL1');

INSERT INTO tbl1 (c1, c2) VALUES (1, 'aaa') RETURNING c1, c2;
 c1 |  c2 
----+-----
  1 | aaa 
(1 row)

-- RETURNING the whole row
INSERT INTO tbl1 (c1, c2) VALUES (1, 'aaa') RETURNING tb1;
   tb1
---------
(1, aaa,)
(1 row)
```
