### PR TITLE
Add `IMPORT FOREIGN SCHEMA` options

### DIFF
--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -607,6 +607,12 @@ following:
   - **readonly**: sets the **readonly** option on all imported tables
 
     See the [Options](#3-options) section for details.
+    
+  - **import_tables**: allow automated import of tables, default `true`.
+
+  - **import_views**: allow automated import of views, default `true`.
+  
+  - **import_materialized_views**: allow automated import of materialized views, default `true`.
 
   - **max_long**: sets the **max_long** option on all imported tables
 

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -223,7 +223,7 @@ extern void oracleGetLob(oracleSession *session, void *locptr, oraType type, cha
 extern void oracleClientVersion(int *major, int *minor, int *update, int *patch, int *port_patch);
 extern void oracleServerVersion(oracleSession *session, int *major, int *minor, int *update, int *patch, int *port_patch);
 extern void *oracleGetGeometryType(oracleSession *session);
-extern int oracleGetImportColumn(oracleSession *session, char *dblink, char *schema, char *limit_to, char **tabname, char **colname, oraType *type, int *charlen, int *typeprec, int *typescale, int *nullable, int *key);
+extern int oracleGetImportColumn(oracleSession *session, char *dblink, char *schema, char *limit_to, char **tabname, char **colname, oraType *type, int *charlen, int *typeprec, int *typescale, int *nullable, int *key, bool export_tables, bool export_views, bool export_materialized_views);
 
 /*
  * functions defined in oracle_fdw.c

--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -2511,25 +2511,42 @@ void *oracleGetGeometryType(oracleSession *session)
  * 		Get the next element in the ordered list of tables and their columns for "schema".
  * 		Returns 0 if there are no more columns, -1 if the remote schema does not exist, else 1.
  */
-int oracleGetImportColumn(oracleSession *session, char *dblink, char *schema, char *limit_to, char **tabname, char **colname, oraType *type, int *charlen, int *typeprec, int *typescale, int *nullable, int *key)
+int oracleGetImportColumn(oracleSession *session, char *dblink, char *schema, char *limit_to, char **tabname, char **colname, oraType *type, int *charlen, int *typeprec, int *typescale, int *nullable, int *key, bool export_tables, bool export_views, bool export_materialized_views);
 {
 	/* the static variables will contain data returned to the caller */
 	static char s_tabname[129], s_colname[129];
 	char typename[129] = { '\0' }, typeowner[129] = { '\0' }, isnull[2] = { '\0' };
 	int count = 0;
+	/* Object_type constats for partial import */
+	const char * const ot_table = "TABLE";
+	/* Also there is "TABLE PARTITION" and "TABLE SUBPARTITION" not applicable values */
+	const char * const ot_view = "VIEW";
+	const char * const ot_materialized_view = "MATERIALIZED VIEW";
 	const char * const schema_query = "SELECT COUNT(*) FROM all_users WHERE username = :nsp";
 	const char * const column_query_template =
 		"SELECT col.table_name, col.column_name, col.data_type, col.data_type_owner,\n"
 		"       col.char_length, col.data_precision, col.data_scale, col.nullable,\n"
-		"       CASE WHEN primkey_col.position IS NOT NULL THEN 1 ELSE 0 END AS primary_key\n"
-		"FROM all_tab_columns%s col,\n"
+		"       CASE WHEN primkey_col.position IS NOT NULL THEN 1 ELSE 0 END AS primary_key,\n"
+		"       obj.object_type\n"
+		"  FROM all_tab_columns%s col\n"
+		"  LEFT JOIN\n"
 		"     (SELECT con.table_name, cons_col.column_name, cons_col.position\n"
-		"      FROM all_constraints%s con, all_cons_columns%s cons_col\n"
-		"      WHERE con.owner = cons_col.owner AND con.table_name = cons_col.table_name\n"
-		"        AND con.constraint_name = cons_col.constraint_name\n"
-		"        AND con.constraint_type = 'P' AND con.owner = :nsp) primkey_col\n"
-		"WHERE col.table_name = primkey_col.table_name(+) AND col.column_name = primkey_col.column_name(+)\n"
-		"  AND col.owner = :nsp\n"
+		"        FROM all_constraints%s con, all_cons_columns%s cons_col\n"
+		"       WHERE con.owner = cons_col.owner\n"
+		"         AND con.table_name = cons_col.table_name\n"
+		"         AND con.constraint_name = cons_col.constraint_name\n"
+		"         AND con.constraint_type = 'P'\n"
+		"         AND con.owner = :nsp) primkey_col\n"
+		"   ON col.table_name = primkey_col.table_name\n"
+		"  AND col.column_name = primkey_col.column_name\n"
+		"INNER JOIN ALL_OBJECTS obj\n"
+		"   ON col.table_name = obj.object_name\n"
+		"  AND col.owner = obj.owner\n"
+		"WHERE col.owner = :nsp\n"
+		/*
+		 * TODO: use bool export_tables, bool export_views, bool export_materialized_views
+		 * to filter object_type
+	  	 */
 		"%s%s%sORDER BY col.table_name, col.column_id";
 	char *column_query = NULL, *table_suffix = NULL;
 	OCIBind *bndhp = NULL;


### PR DESCRIPTION
This is a draft for https://github.com/laurenz/oracle_fdw/issues/656. @laurenz , feel free to use and modify it. In this PR
- Add `import_tables`, `import_views`, `import_materialized_views` options in `README` file,
- Add a function for parsing boolean value of some option
- Add values parsing for `import_tables`, `import_views`, `import_materialized_views` options,
- Add `import_tables`, `import_views`, `import_materialized_views` in `oracleGetImportColumn` signature,
- Modify the main query in `oracleGetImportColumn` to more ISO:SQL style and add `object_type`. Final query version is 
```sql
SELECT col.table_name, col.column_name, col.data_type, col.data_type_owner,
       col.char_length, col.data_precision, col.data_scale, col.nullable,
       CASE WHEN primkey_col.position IS NOT NULL THEN 1 ELSE 0 END AS primary_key,
       obj.object_type      
  FROM all_tab_columns col
  LEFT JOIN     
     (SELECT con.table_name, cons_col.column_name, cons_col.position
        FROM all_constraints con, all_cons_columns cons_col
       WHERE con.owner = cons_col.owner
         AND con.table_name = cons_col.table_name
         AND con.constraint_name = cons_col.constraint_name
         AND con.constraint_type = 'P'
         AND con.owner = :nsp) primkey_col
   ON col.table_name = primkey_col.table_name
  AND col.column_name = primkey_col.column_name
INNER JOIN ALL_OBJECTS obj
   ON col.table_name = obj.object_name
  AND col.owner = obj.owner
WHERE col.owner = :nsp
ORDER BY col.table_name, col.column_id;
```
You can add `AND object_type  IN ('...', '...')` in `WHERE` based on new flags and your preferred code style. Sorry for my not complete PR, I am just C beginner from [sqlite_fdw](https://github.com/pgspider/sqlite_fdw/commits/master/).