### PR TITLE
fix spelling mistakein README.oracle_fdw

### DIFF
--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -444,7 +444,7 @@ required tables.
 
 Similarly, ORDER BY clauses will be pushed down to Oracle wherever possible.
 Note that no ORDER BY condition that sorts by a character string will be
-pushed down as the sort orders in PostgreSQL an Oracle cannot be guaranteed
+pushed down as the sort orders in PostgreSQL and Oracle cannot be guaranteed
 to be the same.
 
 To make use of that, try to use simple conditions for the foreign table.


### PR DESCRIPTION
This pull request addresses a minor spelling mistake in the `README.oracle_fdw` file, changing `an` to `and`.