### PR TITLE
Build error on postgreSQL 18dev

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -25,7 +25,13 @@
 #include "catalog/pg_user_mapping.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
+/* for "explain" or "explain_state" */
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#include "executor/executor.h"
+#else
 #include "commands/explain.h"
+#endif  /* PG_VERSION_NUM */
 #if PG_VERSION_NUM >= 180000
 #include "commands/explain_format.h"
 #endif  /* PG_VERSION_NUM */


### PR DESCRIPTION
Hello,

Build is failed with following error:
```
oracle_fdw.c:337:62: error: unknown type name ‘ExplainState’; did you mean ‘ExplainStmt’?
  337 | static void oracleExplainForeignScan(ForeignScanState *node, ExplainState *es);
      |                                                              ^~~~~~~~~~~~
      |                                                              ExplainStmt
oracle_fdw.c: In function ‘oracle_fdw_handler’:
oracle_fdw.c:453:42: error: ‘oracleExplainForeignScan’ undeclared (first use in this function); did you mean ‘oracleReScanForeignScan’?
  453 |         fdwroutine->ExplainForeignScan = oracleExplainForeignScan;
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                          oracleReScanForeignScan
oracle_fdw.c:453:42: note: each undeclared identifier is reported only once for each function it appears in
oracle_fdw.c: At top level:
oracle_fdw.c:1221:50: error: unknown type name ‘ExplainState’; did you mean ‘ExplainStmt’?
1221 | oracleExplainForeignScan(ForeignScanState *node, ExplainState *es)
      |                                                  ^~~~~~~~~~~~
      |                                                  ExplainStmt
make: *** [<builtin>: oracle_fdw.o] Error 1
```
 
"ExplainState" appears to be defined in PostgreSQL in `src/include/commands/explain_state.h`.
```bash
# source code in postgreSQL
$ grep -rwn ExplainState ./src/include/commands/ | grep -e define -e typedef
./src/include/commands/explain.h:19:struct ExplainState;			/* defined in explain_state.h */
./src/include/commands/explain_state.h:44:typedef struct ExplainState
./src/include/commands/explain_state.h:79:typedef void (*ExplainOptionHandler) (ExplainState *, DefElem *, ParseState *);
./src/include/commands/explain_state.h:82:typedef void (*explain_validate_options_hook_type) (struct ExplainState *es, List *options,
```
 
However, `oracle_fdw.c` does not include `explain_state.h`.
```
# source code in oracle_fdw
$ grep "explain" ./oracle_fdw.c
#include "commands/explain.h"
#include "commands/explain_format.h"
        elog(DEBUG1, "oracle_fdw: explain foreign table scan");
                /* add it to explain text */
        elog(DEBUG1, "oracle_fdw: explain foreign table modify on %d", RelationGetRelid(rinfo->ri_RelationDesc));
```
 
If I add following fix in `oracle_fdw.c`, build is succeeded.
```diff
#include "catalog/pg_user_mapping.h"
#include "catalog/pg_type.h"
#include "commands/defrem.h"
+ /* for "explain" or "explain_state" */
+ #if PG_VERSION_NUM >= 180000
+ #include "commands/explain_state.h"
+ #include "executor/executor.h"
+ #else
+ #include "commands/explain.h"
+ #endif  /* PG_VERSION_NUM */
#if PG_VERSION_NUM >= 180000
#include "commands/explain_format.h"
#endif  /* PG_VERSION_NUM */
```
 
- executor/executor.h is also required because build without it will result in the following warning:
 
```
oracle_fdw.c: In function ‘oracleBeginForeignScan’:
oracle_fdw.c:1278:30: warning: implicit declaration of function ‘ExecInitExprList’ [-Wimplicit-function-declaration]
1278 |         exec_exprs = (List *)ExecInitExprList(fsplan->fdw_exprs, (PlanState *)node);
      |                              ^~~~~~~~~~~~~~~~
oracle_fdw.c:1278:22: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
1278 |         exec_exprs = (List *)ExecInitExprList(fsplan->fdw_exprs, (PlanState *)node);
      |                      ^
oracle_fdw.c: In function ‘oracleBeginForeignModify’:
oracle_fdw.c:1879:25: warning: implicit declaration of function ‘ExecFindJunkAttributeInTlist’ [-Wimplicit-function-declaration]
1879 |                         ExecFindJunkAttributeInTlist(subplan->targetlist,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
oracle_fdw.c: In function ‘oracleBeginForeignInsert’:
oracle_fdw.c:1958:22: warning: implicit declaration of function ‘ExecGetResultRelCheckAsUser’ [-Wimplicit-function-declaration]
1958 |         check_user = ExecGetResultRelCheckAsUser(rinfo, estate);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
oracle_fdw.c: In function ‘setModifyParameters’:
oracle_fdw.c:6094:33: warning: implicit declaration of function ‘ExecGetJunkAttribute’ [-Wimplicit-function-declaration]
6094 |                         datum = ExecGetJunkAttribute(oldslot, oraTable->cols[param->colnum]->pkey, &isnull);
      |                                 ^~~~~~~~~~~~~~~~~~~~
oracle_fdw.c: In function ‘setSelectParameters’:
oracle_fdw.c:6585:33: warning: implicit declaration of function ‘ExecEvalExpr’ [-Wimplicit-function-declaration]
6585 |                         datum = ExecEvalExpr((ExprState *)(param->node), econtext, &is_null);
      |                                 ^~~~~~~~~~~~
```
 
This build error was caused by following postgres commits:
https://github.com/postgres/postgres/commit/c65bc2e1d14a2d4daed7c1921ac518f2c5ac3d17