### PR TITLE
Support setting fixed timezone for remote server 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ msvc/x64
 # language servers
 **/compile_commands.json
 .cache
+.clangd
 
 # vscode settings
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ msvc/*.suo
 msvc/*.vcxproj.filters
 msvc/Win32
 msvc/x64
+
+# language servers
+**/compile_commands.json
+.cache
+
+# vscode settings
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 endif
 
+$(OBJS): CFLAGS += $(PERMIT_DECLARATION_AFTER_STATEMENT)
+
 # Oracle's shared library is oci.dll on Windows and libclntsh elsewhere
 ifeq ($(PORTNAME),win32)
 ORACLE_SHLIB=oci

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ DOCS = README.oracle_fdw
 REGRESS = oracle_fdw oracle_gis oracle_import oracle_join
 
 # try to find Instant Client installations installed in standard paths
-FIND_INCLUDE := $(wildcard /usr/include/oracle/*/client64 /usr/include/oracle/*/client)
-FIND_LIBDIRS := $(wildcard /usr/lib/oracle/*/client64/lib /usr/lib/oracle/*/client/lib)
+FIND_INCLUDE := $(wildcard /usr/include/oracle/*/client64 /usr/include/oracle/*/client /usr/include/oracle)
+FIND_LIBDIRS := $(wildcard /usr/lib/oracle/*/client64/lib /usr/lib/oracle/*/client/lib /usr/lib/oracle)
 
 FIND_CPPFLAGS = $(foreach DIR,$(FIND_INCLUDE),-I$(DIR))
 FIND_LDFLAGS = $(foreach DIR,$(FIND_LIBDIRS),-L$(DIR))

--- a/README.oracle_fdw
+++ b/README.oracle_fdw
@@ -218,6 +218,19 @@ Foreign server options
   In that case, either use a different `timezone` or leave the option set `off`
   and set the environment variable ORA_SDTZ to an appropriate value in the
   environment of the PostgreSQL server.
+  
+- **date_timezone** (string, optional)
+  
+  Time zone for automatic conversion of DATE and TIMESTAMP (without time zone) 
+  Oracle types to `timestamptz` Postgres type and back, if that type is 
+  specifiend in the foreign table. Without this option, the time zone part is 
+  dropped if DATE or TIMESTAMP is converted/coerced into/from `timestamptz`. 
+  
+  The option's value must be a valid Oracle time zone (it is substituted into 
+  query code). Empty value is disallowed. Automatic server timezone detection
+  is not supported (yet).
+  
+  This option is unrelated to **set_timezone**.
 
 User mapping options
 --------------------
@@ -433,6 +446,11 @@ setting the `set_timezone` option on the foreign server.
 If you want to convert TIMESTAMP WITH LOCAL TIME ZONE to `timestamp`, consider
 setting the `set_timezone` option on the foreign server.
 
+If you want to convert DATE and TIMESTAMP to `timestamptz`, consider
+setting the `date_timezone` option on the foreign server. Additionally, use
+`date_as_timestamptz` and `timestamp_as_timestamptz` options for IMPORT FOREIGN
+SCHEMA, or set PostgreSQL type to `timestamptz` in foreign table definition.
+
 If you need conversions exceeding the above, define an appropriate view in
 Oracle or PostgreSQL.
 
@@ -642,6 +660,14 @@ following:
   - **set_timezone**: sets the **set_timezone** option on all imported tables
 
     See the [Options](#3-options) section for details.
+
+  - **date_as_timestamptz**: converts DATE columns to `timestamptz`. 
+    
+    Requires **date_timezone** server option
+  
+  - **timestamp_as_timestamptz**: converts TIMESTAMP columns to `timestamptz`. 
+    
+    Requires **date_timezone** server option
 
 - The Oracle schema name must be written exactly as it is in Oracle, so
   normally in upper case.  Since PostgreSQL translates names to lower case

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -1074,3 +1074,4 @@ SELECT * FROM typetest3_raw ORDER BY id;
   2 | Thu Dec 31 03:00:00 2020 | Thu Dec 31 03:00:00 2020
   3 | Thu Dec 31 05:30:00 2020 | Thu Dec 31 05:30:00 2020
 (3 rows)
+

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -5,7 +5,7 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true', set_timezone 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true', set_timezone 'true', date_timezone 'Europe/Moscow');
 CREATE USER MAPPING FOR CURRENT_ROLE SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 -- drop the Oracle objects if they exist
 DO
@@ -32,6 +32,13 @@ END;$$;
 DO
 $$BEGIN
    SELECT oracle_execute('oracle', 'DROP TABLE scott.typetest2 PURGE');
+EXCEPTION
+   WHEN OTHERS THEN
+      NULL;
+END;$$;
+DO
+$$BEGIN
+   SELECT oracle_execute('oracle', 'DROP TABLE scott.typetest3 PURGE');
 EXCEPTION
    WHEN OTHERS THEN
       NULL;
@@ -97,6 +104,20 @@ SELECT oracle_execute(
 ----------------
  
 (1 row)
+       
+SELECT oracle_execute(
+          'oracle',
+          E'CREATE TABLE scott.typetest3 (\n'
+          '   id  NUMBER(5)\n'
+          '     CONSTRAINT typetest3_pkey PRIMARY KEY,\n'
+          '   d DATE,\n'
+          '   ts TIMESTAMP\n'
+          ') SEGMENT CREATION IMMEDIATE'
+       );
+ oracle_execute 
+----------------
+ 
+(1 row)
 
 SELECT oracle_execute(
           'oracle',
@@ -136,6 +157,17 @@ SELECT oracle_execute(
 SELECT oracle_execute(
           'oracle',
           E'BEGIN\n'
+          '   DBMS_STATS.GATHER_TABLE_STATS (''SCOTT'', ''TYPETEST3'', NULL, 100);\n'
+          'END;'
+       );
+ oracle_execute 
+----------------
+ 
+(1 row)
+
+SELECT oracle_execute(
+          'oracle',
+          E'BEGIN\n'
           '   DBMS_STATS.GATHER_TABLE_STATS (''SCOTT'', ''GIS'', NULL, 100);\n'
           'END;'
        );
@@ -152,6 +184,20 @@ SELECT oracle_execute(
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC''),\n'
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC''),\n'
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC'')\n'
+          ')'
+       );
+ oracle_execute 
+----------------
+ 
+(1 row)
+
+-- initial data for typetest3
+SELECT oracle_execute(
+          'oracle',
+          E'INSERT INTO scott.typetest3 (id, d, ts) VALUES (\n'
+          '   1,\n'
+          '   CAST(''2002-08-01 00:00:00 AD'' AS date),\n'
+          '   CAST(''2002-08-01 00:00:00 AD'' AS timestamp)\n'
           ')'
        );
  oracle_execute 
@@ -228,6 +274,11 @@ CREATE FOREIGN TABLE typetest2 (
    ts2 timestamp without time zone,
    ts3 date
 ) SERVER oracle OPTIONS (table 'TYPETEST2');
+CREATE FOREIGN TABLE typetest3 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   d timestamp with time zone,
+   ts timestamp with time zone
+) SERVER oracle OPTIONS (table 'TYPETEST3');
 /*
  * INSERT some rows into "typetest1".
  */
@@ -967,3 +1018,59 @@ SELECT oracle_close_connections();
  
 (1 row)
 
+/* test DATE to timestamp with time zone conversion 
+PDT = -07:00
+PST = -08:00
+Europe/Moscow = +03:00 (+04:00 for summer 2002)
+Asia/Kolkata = +05:30
+*/
+INSERT INTO typetest3 (id, d, ts) VALUES (
+   2,
+   '2020-12-31 00:00:00 UTC',
+   '2020-12-31 00:00:00 UTC'
+);
+SELECT * FROM typetest3 ORDER BY id;
+ id |              d               |              ts              
+----+------------------------------+------------------------------
+  1 | Wed Jul 31 13:00:00 2002 PDT | Wed Jul 31 13:00:00 2002 PDT
+  2 | Wed Dec 30 16:00:00 2020 PST | Wed Dec 30 16:00:00 2020 PST
+(2 rows)
+
+/* 
+row 1 was midnight Moscow time (+04:00). Viewed from default Postgres time zone (Los Angeles, -07:00 for summer or -08:00 for winter) the time should be decreased by 11 hours
+row 2 was inserted as midnight UTC. Viewed from Los Angeles (-08:00 for winter time, PDT) the time should decrease by 8 hours
+*/
+BEGIN;
+alter server oracle options (set date_timezone 'Asia/Kolkata');
+INSERT INTO typetest3 (id, d, ts) VALUES (
+   3,
+   '2020-12-31 00:00:00 UTC',
+   '2020-12-31 00:00:00 UTC'
+);
+SELECT * FROM typetest3 ORDER BY id;
+ id |              d               |              ts              
+----+------------------------------+------------------------------
+  1 | Wed Jul 31 11:30:00 2002 PDT | Wed Jul 31 11:30:00 2002 PDT
+  2 | Wed Dec 30 13:30:00 2020 PST | Wed Dec 30 13:30:00 2020 PST
+  3 | Wed Dec 30 16:00:00 2020 PST | Wed Dec 30 16:00:00 2020 PST
+(3 rows)
+
+/* 
+row 1 is now midnight Kolkata, viewed from Los Angeles. So the time should decrease by 1:30
+row 2 was inserted as 03:00 Moscow time (+03:00). It is now 03:00 Kolkata (+05:30), so should decrease by 2:30
+row 3 should be Dec 30 16:00 as viewed from PST
+*/
+COMMIT;
+/* table to check dates as they are stored on the Oracle side */
+CREATE FOREIGN TABLE typetest3_raw (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   d timestamp without time zone,
+   ts timestamp without time zone
+) SERVER oracle OPTIONS (table 'TYPETEST3');
+SELECT * FROM typetest3_raw ORDER BY id;
+ id |            d             |            ts            
+----+--------------------------+--------------------------
+  1 | Thu Aug 01 00:00:00 2002 | Thu Aug 01 00:00:00 2002
+  2 | Thu Dec 31 03:00:00 2020 | Thu Dec 31 03:00:00 2020
+  3 | Thu Dec 31 05:30:00 2020 | Thu Dec 31 05:30:00 2020
+(3 rows)

--- a/expected/oracle_fdw.out
+++ b/expected/oracle_fdw.out
@@ -1075,3 +1075,58 @@ SELECT * FROM typetest3_raw ORDER BY id;
   3 | Thu Dec 31 05:30:00 2020 | Thu Dec 31 05:30:00 2020
 (3 rows)
 
+/* check conditions on converted columns working */
+EXPLAIN(costs off)
+SELECT * FROM typetest3 WHERE d = '2020-12-31 00:00:00 UTC' ORDER BY id;
+                                                                                                                                                                QUERY PLAN                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on typetest3
+   Oracle query: SELECT /*11a72aeb292e958e*/ r1."ID", FROM_TZ(CAST(r1."D" AS TIMESTAMP), 'Asia/Kolkata'), FROM_TZ(r1."TS", 'Asia/Kolkata') FROM "TYPETEST3" r1 WHERE (r1."D" = CAST((CAST ('2020-12-30 16:00:00.000000-08:00 AD' AS TIMESTAMP WITH TIME ZONE)) AT TIME ZONE 'Asia/Kolkata' AS TIMESTAMP)) ORDER BY r1."ID" ASC NULLS LAST
+(2 rows)
+
+SELECT * FROM typetest3 WHERE d = '2020-12-31 00:00:00 UTC' ORDER BY id;
+ id |              d               |              ts              
+----+------------------------------+------------------------------
+  3 | Wed Dec 30 16:00:00 2020 PST | Wed Dec 30 16:00:00 2020 PST
+(1 row)
+
+PREPARE stmt(integer, date, timestamp) AS SELECT d FROM typetest3 WHERE id = $1 AND d < $2 AND $3 > ts;
+-- six executions to switch to generic plan
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+              d               
+------------------------------
+ Wed Jul 31 11:30:00 2002 PDT
+(1 row)
+
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+              d               
+------------------------------
+ Wed Jul 31 11:30:00 2002 PDT
+(1 row)
+
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+              d               
+------------------------------
+ Wed Jul 31 11:30:00 2002 PDT
+(1 row)
+
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+              d               
+------------------------------
+ Wed Jul 31 11:30:00 2002 PDT
+(1 row)
+
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+              d               
+------------------------------
+ Wed Jul 31 11:30:00 2002 PDT
+(1 row)
+
+EXPLAIN (COSTS off) EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on typetest3
+   Oracle query: SELECT /*5cf4e46b38a8de85*/ r1."ID", FROM_TZ(CAST(r1."D" AS TIMESTAMP), 'Asia/Kolkata'), FROM_TZ(r1."TS", 'Asia/Kolkata') FROM "TYPETEST3" r1 WHERE (r1."D" < CAST(FROM_TZ(CAST(CAST (:p1 AS DATE) AS TIMESTAMP), 'America/Los_Angeles') AT TIME ZONE 'Asia/Kolkata' AS TIMESTAMP)) AND (CAST(FROM_TZ(CAST(CAST (:p2 AS TIMESTAMP) AS TIMESTAMP), 'America/Los_Angeles') AT TIME ZONE 'Asia/Kolkata' AS TIMESTAMP) > r1."TS") AND (r1."ID" = :p3)
+(2 rows)
+
+DEALLOCATE stmt;

--- a/expected/oracle_import.out
+++ b/expected/oracle_import.out
@@ -79,7 +79,7 @@ IMPORT FOREIGN SCHEMA "SCOTT"
    LIMIT TO (typetest3)
    FROM SERVER oracle
    INTO import
-   OPTIONS (date_as_timestamptz 'true');
+   OPTIONS (date_as_timestamptz 'true', timestamp_as_timestamptz 'true');
 SELECT t.relname, a.attname, a.atttypid::regtype, a.attfdwoptions
 FROM pg_attribute AS a
    JOIN pg_class AS t ON t.oid = a.attrelid
@@ -94,3 +94,4 @@ ORDER BY t.relname, a.attnum;
  typetest3 | d       | timestamp with time zone | 
  typetest3 | ts      | timestamp with time zone | 
 (3 rows)
+

--- a/expected/oracle_import.out
+++ b/expected/oracle_import.out
@@ -74,3 +74,23 @@ ORDER BY t.relname, a.attnum;
  typetest1 | iym     | interval                    | 
 (25 rows)
 
+/* import date/timestamp as timestamp with time zone (relies on date_timezone server option) */
+IMPORT FOREIGN SCHEMA "SCOTT"
+   LIMIT TO (typetest3)
+   FROM SERVER oracle
+   INTO import
+   OPTIONS (date_as_timestamptz 'true');
+SELECT t.relname, a.attname, a.atttypid::regtype, a.attfdwoptions
+FROM pg_attribute AS a
+   JOIN pg_class AS t ON t.oid = a.attrelid
+WHERE t.relname IN ('typetest3')
+  AND a.attnum > 0
+  AND t.relnamespace = 'import'::regnamespace
+  AND NOT a.attisdropped
+ORDER BY t.relname, a.attnum;
+  relname  | attname |         atttypid         | attfdwoptions 
+-----------+---------+--------------------------+---------------
+ typetest3 | id      | integer                  | {key=true}
+ typetest3 | d       | timestamp with time zone | 
+ typetest3 | ts      | timestamp with time zone | 
+(3 rows)

--- a/oracle_fdw.h
+++ b/oracle_fdw.h
@@ -103,6 +103,13 @@ typedef enum
 	ORA_TYPE_OTHER
 } oraType;
 
+/* [max] value lengths of some Oracle types */
+/* date and timestamp can be converted/presented as timestamp with time zone for Postgres, so the length needs to be adjusted */
+#define ORA_TYPE_DATE_LEN 23
+#define ORA_TYPE_TIMESTAMP_LEN 34
+#define ORA_TYPE_TIMESTAMPTZ_LEN 40
+#define ORA_TYPE_TIMESTAMPLTZ_LEN 40
+
 /* Some PostgreSQL versions have no constant definition for the OID of type uuid */
 #ifndef UUIDOID
 #define UUIDOID 2950

--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -1170,22 +1170,22 @@ struct oraTable
 			case SQLT_DAT:
 				/* DATE */
 				reply->cols[i-1]->oratype = ORA_TYPE_DATE;
-				reply->cols[i-1]->val_size = 23;
+				reply->cols[i-1]->val_size = ORA_TYPE_DATE_LEN;
 				break;
 			case SQLT_TIMESTAMP:
 				/* TIMESTAMP */
 				reply->cols[i-1]->oratype = ORA_TYPE_TIMESTAMP;
-				reply->cols[i-1]->val_size = 34;
+				reply->cols[i-1]->val_size = ORA_TYPE_TIMESTAMP_LEN;
 				break;
 			case SQLT_TIMESTAMP_TZ:
 				/* TIMESTAMP WITH TIMEZONE */
 				reply->cols[i-1]->oratype = ORA_TYPE_TIMESTAMPTZ;
-				reply->cols[i-1]->val_size = 40;
+				reply->cols[i-1]->val_size = ORA_TYPE_TIMESTAMPTZ_LEN;
 				break;
 			case SQLT_TIMESTAMP_LTZ:
 				/* TIMESTAMP WITH LOCAL TIMEZONE */
 				reply->cols[i-1]->oratype = ORA_TYPE_TIMESTAMPLTZ;
-				reply->cols[i-1]->val_size = 40;
+				reply->cols[i-1]->val_size = ORA_TYPE_TIMESTAMPLTZ_LEN;
 				break;
 			case SQLT_INTERVAL_YM:
 				/* INTERVAL YEAR TO MONTH */

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -715,3 +715,18 @@ CREATE FOREIGN TABLE typetest3_raw (
 ) SERVER oracle OPTIONS (table 'TYPETEST3');
 
 SELECT * FROM typetest3_raw ORDER BY id;
+
+/* check conditions on converted columns working */
+EXPLAIN(costs off)
+SELECT * FROM typetest3 WHERE d = '2020-12-31 00:00:00 UTC' ORDER BY id;
+SELECT * FROM typetest3 WHERE d = '2020-12-31 00:00:00 UTC' ORDER BY id;
+
+PREPARE stmt(integer, date, timestamp) AS SELECT d FROM typetest3 WHERE id = $1 AND d < $2 AND $3 > ts;
+-- six executions to switch to generic plan
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+EXPLAIN (COSTS off) EXECUTE stmt(1, '2011-03-09', '2011-03-09 05:00:00');
+DEALLOCATE stmt;

--- a/sql/oracle_fdw.sql
+++ b/sql/oracle_fdw.sql
@@ -8,7 +8,7 @@ SET client_min_messages = WARNING;
 CREATE EXTENSION oracle_fdw;
 
 -- TWO_TASK or ORACLE_HOME and ORACLE_SID must be set in the server's environment for this to work
-CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true', set_timezone 'true');
+CREATE SERVER oracle FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver '', isolation_level 'read_committed', nchar 'true', set_timezone 'true', date_timezone 'Europe/Moscow');
 
 CREATE USER MAPPING FOR CURRENT_ROLE SERVER oracle OPTIONS (user 'SCOTT', password 'tiger');
 
@@ -40,6 +40,14 @@ END;$$;
 DO
 $$BEGIN
    SELECT oracle_execute('oracle', 'DROP TABLE scott.typetest2 PURGE');
+EXCEPTION
+   WHEN OTHERS THEN
+      NULL;
+END;$$;
+
+DO
+$$BEGIN
+   SELECT oracle_execute('oracle', 'DROP TABLE scott.typetest3 PURGE');
 EXCEPTION
    WHEN OTHERS THEN
       NULL;
@@ -95,6 +103,16 @@ SELECT oracle_execute(
           '   ts3 TIMESTAMP WITH LOCAL TIME ZONE\n'
           ') SEGMENT CREATION IMMEDIATE'
        );
+       
+SELECT oracle_execute(
+          'oracle',
+          E'CREATE TABLE scott.typetest3 (\n'
+          '   id  NUMBER(5)\n'
+          '     CONSTRAINT typetest3_pkey PRIMARY KEY,\n'
+          '   d DATE,\n'
+          '   ts TIMESTAMP\n'
+          ') SEGMENT CREATION IMMEDIATE'
+       );
 
 SELECT oracle_execute(
           'oracle',
@@ -122,6 +140,13 @@ SELECT oracle_execute(
 SELECT oracle_execute(
           'oracle',
           E'BEGIN\n'
+          '   DBMS_STATS.GATHER_TABLE_STATS (''SCOTT'', ''TYPETEST3'', NULL, 100);\n'
+          'END;'
+       );
+
+SELECT oracle_execute(
+          'oracle',
+          E'BEGIN\n'
           '   DBMS_STATS.GATHER_TABLE_STATS (''SCOTT'', ''GIS'', NULL, 100);\n'
           'END;'
        );
@@ -134,6 +159,16 @@ SELECT oracle_execute(
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC''),\n'
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC''),\n'
           '   FROM_TZ(CAST (''2002-08-01 00:00:00 AD'' AS timestamp), ''UTC'')\n'
+          ')'
+       );
+
+-- initial data for typetest3
+SELECT oracle_execute(
+          'oracle',
+          E'INSERT INTO scott.typetest3 (id, d, ts) VALUES (\n'
+          '   1,\n'
+          '   CAST(''2002-08-01 00:00:00 AD'' AS date),\n'
+          '   CAST(''2002-08-01 00:00:00 AD'' AS timestamp)\n'
           ')'
        );
 
@@ -205,6 +240,12 @@ CREATE FOREIGN TABLE typetest2 (
    ts2 timestamp without time zone,
    ts3 date
 ) SERVER oracle OPTIONS (table 'TYPETEST2');
+
+CREATE FOREIGN TABLE typetest3 (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   d timestamp with time zone,
+   ts timestamp with time zone
+) SERVER oracle OPTIONS (table 'TYPETEST3');
 
 /*
  * INSERT some rows into "typetest1".
@@ -634,3 +675,43 @@ SELECT * FROM typetest2 ORDER BY id;
 COMMIT;
 -- we need to re-establish the connection after changing "timezone"
 SELECT oracle_close_connections();
+
+/* test DATE to timestamp with time zone conversion 
+PDT = -07:00
+PST = -08:00
+Europe/Moscow = +03:00 (+04:00 for summer 2002)
+Asia/Kolkata = +05:30
+*/
+INSERT INTO typetest3 (id, d, ts) VALUES (
+   2,
+   '2020-12-31 00:00:00 UTC',
+   '2020-12-31 00:00:00 UTC'
+);
+SELECT * FROM typetest3 ORDER BY id;
+/* 
+row 1 was midnight Moscow time (+04:00). Viewed from default Postgres time zone (Los Angeles, -07:00 for summer or -08:00 for winter) the time should be decreased by 11 hours
+row 2 was inserted as midnight UTC. Viewed from Los Angeles (-08:00 for winter time, PDT) the time should decrease by 8 hours
+*/
+BEGIN;
+alter server oracle options (set date_timezone 'Asia/Kolkata');
+INSERT INTO typetest3 (id, d, ts) VALUES (
+   3,
+   '2020-12-31 00:00:00 UTC',
+   '2020-12-31 00:00:00 UTC'
+);
+SELECT * FROM typetest3 ORDER BY id;
+/* 
+row 1 is now midnight Kolkata, viewed from Los Angeles. So the time should decrease by 1:30
+row 2 was inserted as 03:00 Moscow time (+03:00). It is now 03:00 Kolkata (+05:30), so should decrease by 2:30
+row 3 should be Dec 30 16:00 as viewed from PST
+*/
+COMMIT;
+
+/* table to check dates as they are stored on the Oracle side */
+CREATE FOREIGN TABLE typetest3_raw (
+   id  integer OPTIONS (key 'yes') NOT NULL,
+   d timestamp without time zone,
+   ts timestamp without time zone
+) SERVER oracle OPTIONS (table 'TYPETEST3');
+
+SELECT * FROM typetest3_raw ORDER BY id;

--- a/sql/oracle_import.sql
+++ b/sql/oracle_import.sql
@@ -44,7 +44,7 @@ IMPORT FOREIGN SCHEMA "SCOTT"
    LIMIT TO (typetest3)
    FROM SERVER oracle
    INTO import
-   OPTIONS (date_as_timestamptz 'true');
+   OPTIONS (date_as_timestamptz 'true', timestamp_as_timestamptz 'true');
 
 SELECT t.relname, a.attname, a.atttypid::regtype, a.attfdwoptions
 FROM pg_attribute AS a

--- a/sql/oracle_import.sql
+++ b/sql/oracle_import.sql
@@ -38,3 +38,19 @@ WHERE t.relname IN ('typetest1', 'ttv', 'mattest2')
   AND t.relnamespace = 'import'::regnamespace
   AND NOT a.attisdropped
 ORDER BY t.relname, a.attnum;
+
+/* import date/timestamp as timestamp with time zone (relies on date_timezone server option) */
+IMPORT FOREIGN SCHEMA "SCOTT"
+   LIMIT TO (typetest3)
+   FROM SERVER oracle
+   INTO import
+   OPTIONS (date_as_timestamptz 'true');
+
+SELECT t.relname, a.attname, a.atttypid::regtype, a.attfdwoptions
+FROM pg_attribute AS a
+   JOIN pg_class AS t ON t.oid = a.attrelid
+WHERE t.relname IN ('typetest3')
+  AND a.attnum > 0
+  AND t.relnamespace = 'import'::regnamespace
+  AND NOT a.attisdropped
+ORDER BY t.relname, a.attnum;


### PR DESCRIPTION
This PR allows to avoid data loss in conversions between DATE and timestamp[tz]. It adds several options to set a fixed timezone of the Oracle server to preserve the implicit (server) timezone of DATE and TIMESTAMP Oracle types when converting them to timestamptz Postgres type and back. 

Currently DATEs and TIMESTAMPs are presented as timestamp (local to any timezone) in Postgres, which assumes session's timezone. And even if foreign table's column type is set to timestamptz, the timezone is still assumed to be that of the session. To preserve a fixed/constant timezone a user is required to do explicit conversions from timestamp to timestamptz (and reversed) when working with DATE/TIEMSTAMP columns of foreign tables. This is error prone and unnecessary.

The ugly part right now is the pushdown of predicates. The conversions require analyzing multiple nodes/levels of predicate's expression, but the query is being generated in single step. It would be better to have an intermediate tree representation before stamping out the query for Oracle, where it would be possible to do complex analysis and transformations. The expression tree given by Postgres looks unfitting for this purpose.