### PR TITLE
Disable vcpkg integration for the build

### DIFF
--- a/msvc/oracle_fdw.vcxproj
+++ b/msvc/oracle_fdw.vcxproj
@@ -24,6 +24,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E4E300FC-E7CE-4BAA-9028-AA348F977376}</ProjectGuid>
     <RootNamespace>oracle_fdw</RootNamespace>
+	<VcpkgEnabled>false</VcpkgEnabled>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
If [vcpkg](https://github.com/Microsoft/vcpkg) is present and global integration is enabled, it can interfere with the build by providing incompatible libraries.

Setting the property when vcpkg is not present has no negative effect.