### PR TITLE
use PG_MODULE_MAGIC_EXT in PG18+

### DIFF
--- a/oracle_fdw.c
+++ b/oracle_fdw.c
@@ -160,7 +160,11 @@
 #define table_close(x, y) heap_close(x, y)
 #endif  /* PG_VERSION_NUM */
 
+#if PG_VERSION_NUM >= 180000
+PG_MODULE_MAGIC_EXT(.name = "oracle_fdw", .version = ORACLE_FDW_VERSION);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 /*
  * "true" if Oracle data have been modified in the current transaction.


### PR DESCRIPTION
This allows the extension to report the version of the shared object that is loaded, which goes out through pg_get_loaded_modules(). Though this method not as comprehensive as oracle_diag(), it is the new interface that all extensions are invited to use, and should come at no extra cost as long as ORACLE_FDW_VERSION is the authoritative source of this piece of information.